### PR TITLE
docs: document ROM DFU recovery path

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,11 @@ The short version:
    ```bash
    make flash-all
    ```
-7. Remove the BOOT0 jumper, pinhole reset, close the case — you won't need to open it again
+   If the second `dfu-util` command reports `File downloaded successfully` but
+   fails while submitting `leave`, do not assume the application has booted.
+   Remove the BOOT0 jumper, reset into the USB HID bootloader, and run
+   `make flash` to install the application through the bootloader.
+7. Remove the BOOT0 jumper, pinhole reset, close the case — you won't need to open it again once the application boots
 
 ### Normal Development Cycle (case closed)
 

--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ The short version:
    ```bash
    make flash-all
    ```
-   If the second `dfu-util` command reports `File downloaded successfully` but
-   fails while submitting `leave`, do not assume the application has booted.
-   Remove the BOOT0 jumper, reset into the USB HID bootloader, and run
-   `make flash` to install the application through the bootloader.
+   If the application write finishes but the device does not come up running the
+   app, do not assume it booted. Remove the BOOT0 jumper, reset into the USB HID
+   bootloader, and run `make flash` to install the application through the
+   bootloader.
 7. Remove the BOOT0 jumper, pinhole reset, close the case — you won't need to open it again once the application boots
 
 ### Normal Development Cycle (case closed)

--- a/docs/dfu_mode_guide.md
+++ b/docs/dfu_mode_guide.md
@@ -84,11 +84,13 @@ Harmless warnings you can ignore during step 1:
 
 The line that matters is `Download done. / File downloaded successfully`.
 
-If the bootloader flash succeeds but the application flash ends with
-`File downloaded successfully` followed by an error while submitting `leave`,
-the device may boot only to the USB HID bootloader. That still means the
-one-time ROM DFU work succeeded. Remove the BOOT0 jumper, reset the device, and
-flash the application through the bootloader:
+If the bootloader flash succeeds but the device afterwards comes up on the
+`BOOTLOADER MODE` screen instead of the application, that still means the
+one-time ROM DFU work succeeded. The application write is the second step of
+`make flash-all` and ends by asking the ROM to leave DFU and jump to the app;
+lines like `leave status=... state=...` or `device detached after leave: ...`
+are the normal output of that step, not errors. Remove the BOOT0 jumper, reset
+the device, and flash the application through the bootloader:
 
 ```bash
 cd firmware
@@ -239,10 +241,12 @@ make flash-all
 - **Device doesn't enumerate as DFU:** Make sure you're touching the correct side of the resistor (MCU side, not ground side). Try again — the timing can be tricky.
 - **`dfu-util` not found:** Install with `brew install dfu-util` (macOS) or `apt install dfu-util` (Linux).
 - **Permission denied:** On Linux, you may need udev rules for the AT32 DFU device. Try running with `sudo` first.
-- **`option_bytes48.bin` is not 48 bytes on Linux:** some `/bin/sh`
-  implementations do not interpret `printf '\xHH'` escapes the way bash does.
-  Regenerate the blob with `make SHELL=/bin/bash build/option_bytes48.bin` and
-  confirm `wc -c build/option_bytes48.bin` prints `48`.
+- **`option_bytes48.bin` is not 48 bytes:** the file must be exactly 48 bytes or
+  the ROM DFU rejects the write with "address out of range". Confirm with
+  `wc -c firmware/build/option_bytes48.bin`. This used to go wrong on Linux,
+  where `/bin/sh` is often `dash` and its `printf` does not understand `\xHH`
+  escapes — the blob came out 192 bytes. The Makefile now uses octal escapes,
+  which are portable, so a fresh build should be correct on any shell.
 - **`SET_ADDRESS not correctly executed` for option bytes or internal flash:**
   the ROM DFU can be stuck in a protected/error state. No external programmer is
   required for this recovery path. With the device in ROM DFU, run:
@@ -252,7 +256,14 @@ make flash-all
   It is normal for `dfu-util` to complain about the final state or for the
   device to disappear from USB. Keep BOOT0 high, press pinhole reset or
   unplug/replug USB, verify `dfu-util -l` again, then retry the option-byte and
-  flash commands. This erases the application flash.
+  flash commands.
+
+  **This erases the whole internal flash — use it only when nothing else works.**
+  As well as the application, it destroys anything else you have installed,
+  including the archived stock V1.2.0 image and the high recovery bootloader if
+  you set up the stock/OpenScope switcher (`scripts/switch_firmware.py`). After
+  an unprotect you are back to a bare chip and must redo first-time setup, and
+  you will need to re-archive a stock image before the switcher works again.
 - **Device shows only `BOOTLOADER MODE` after first-time setup:** ROM DFU
   installed the USB HID bootloader, but the application did not boot. Leave
   BOOT0 disconnected and run `cd firmware && make flash` while the bootloader

--- a/docs/dfu_mode_guide.md
+++ b/docs/dfu_mode_guide.md
@@ -84,7 +84,19 @@ Harmless warnings you can ignore during step 1:
 
 The line that matters is `Download done. / File downloaded successfully`.
 
-After this, close the case. All future updates use the USB HID bootloader:
+If the bootloader flash succeeds but the application flash ends with
+`File downloaded successfully` followed by an error while submitting `leave`,
+the device may boot only to the USB HID bootloader. That still means the
+one-time ROM DFU work succeeded. Remove the BOOT0 jumper, reset the device, and
+flash the application through the bootloader:
+
+```bash
+cd firmware
+make flash
+```
+
+Only close the case after the application, not just the bootloader screen, has
+booted. All future updates use the USB HID bootloader:
 1. On the device: **Settings > Firmware Update**
 2. On your computer: `cd firmware && make flash`
 
@@ -227,4 +239,22 @@ make flash-all
 - **Device doesn't enumerate as DFU:** Make sure you're touching the correct side of the resistor (MCU side, not ground side). Try again — the timing can be tricky.
 - **`dfu-util` not found:** Install with `brew install dfu-util` (macOS) or `apt install dfu-util` (Linux).
 - **Permission denied:** On Linux, you may need udev rules for the AT32 DFU device. Try running with `sudo` first.
+- **`option_bytes48.bin` is not 48 bytes on Linux:** some `/bin/sh`
+  implementations do not interpret `printf '\xHH'` escapes the way bash does.
+  Regenerate the blob with `make SHELL=/bin/bash build/option_bytes48.bin` and
+  confirm `wc -c build/option_bytes48.bin` prints `48`.
+- **`SET_ADDRESS not correctly executed` for option bytes or internal flash:**
+  the ROM DFU can be stuck in a protected/error state. No external programmer is
+  required for this recovery path. With the device in ROM DFU, run:
+  ```bash
+  dfu-util -a 0 -d 2e3c:df11 -s :unprotect:force:will-reset -D /dev/null
+  ```
+  It is normal for `dfu-util` to complain about the final state or for the
+  device to disappear from USB. Keep BOOT0 high, press pinhole reset or
+  unplug/replug USB, verify `dfu-util -l` again, then retry the option-byte and
+  flash commands. This erases the application flash.
+- **Device shows only `BOOTLOADER MODE` after first-time setup:** ROM DFU
+  installed the USB HID bootloader, but the application did not boot. Leave
+  BOOT0 disconnected and run `cd firmware && make flash` while the bootloader
+  screen is visible.
 - **Bricked after a bad flash:** You can always re-enter DFU mode with the BOOT0 procedure above. The ROM bootloader is permanent and cannot be overwritten.


### PR DESCRIPTION
## Summary
- document the bootloader-only outcome after a ROM DFU app write/leave failure
- add the no-programmer `unprotect:force` recovery path for AT32 ROM DFU `SET_ADDRESS` failures
- note the Linux `/bin/sh` vs bash `option_bytes48.bin` size check

## Verification
- `git diff --check README.md docs/dfu_mode_guide.md`
- validated against a real first-time flash/recovery session on FNIRSI 2C53T
