### PR TITLE
test: execute the IAP erase guard, and stop reporting skips as passes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,8 +122,43 @@ Issue templates will be added soon to make this easier — until then, just incl
 4. **Sign off your commits** with `git commit -s` (see DCO below).
 5. **Test on hardware if your change touches firmware.** If you can't test on hardware, say so in the PR description — I'll test it on mine before merging, but I need to know that's required.
 6. **Don't reformat files you didn't otherwise touch.** Whitespace-only diffs inside an otherwise substantive PR make review painful. If you want to fix formatting, do it as its own PR.
+7. **Run the test suite and report skips, not just passes** (see below).
 
 I will generally respond to PRs within a few days, but if something is time-sensitive (e.g., it's blocking you from testing something else), say so in the PR title or description and I'll try to prioritize.
+
+### Running the tests
+
+```bash
+python3 scripts/run_tests.py            # all suites; skips are reported prominently
+python3 scripts/run_tests.py --strict   # exit non-zero if anything was skipped
+python3 scripts/run_tests.py -k iap     # just the suites matching a substring
+```
+
+**A skipped test is not a passing test.** Several suites skip when a local artifact
+is missing — the stock archive image (not redistributable) or a firmware binary you
+haven't built yet — and those skips remove real coverage. Build first
+(`make -C firmware`, `make -C firmware/bootloader`, and the `stage0` /
+`stock_dispatcher` / `bootloader_updater` / `high_layout_updater` targets) so the
+checks that inspect **built binaries** actually run. `--strict` is the honest setting
+when you're about to claim a change is verified.
+
+This matters more than it sounds. In August 2026 a bootloader regression that would
+have NACKed half of every flash passed a clean build, the full suite and a manual
+regression hunt, and was caught only when a contributor flashed real hardware. The
+suite could not see it because most of these tests assert on the **text** of the
+source, and the strings they grep for were present in both the correct and the broken
+version.
+
+So, when you touch flash or boot paths:
+
+- **Prefer a test that executes the logic** over one that greps for it.
+  `scripts/test_iap_erase_guard.py` is the worked example: it lifts the guard
+  functions verbatim out of `hid_iap_user.c`, compiles them against a simulated
+  flash array, and checks what actually happened to the flash.
+- **Prove the test can fail.** Reintroduce the bug it's meant to catch and confirm it
+  goes red. An assertion that has never failed hasn't been tested either. The mutation
+  list at the top of `test_iap_erase_guard.py` shows the format — and two of its own
+  assertions were vacuous on the first draft until exactly this exercise caught them.
 
 ### Developer Certificate of Origin
 

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Run every flash-safety / firmware test suite and report skips loudly.
+
+WHY THIS EXISTS
+---------------
+On 2026-08-11 a review reported "49 tests pass" as a clean result. Five tests
+had been skipped because local artifacts were missing, and one of them was
+test_updater_binaries_gap_fill_stock_settings_page -- the only test in the
+whole suite that inspects a real built binary rather than the text of a source
+file. The single highest-value check was silently absent from the number that
+was used to approve the change.
+
+`unittest` prints skips as a quiet "(skipped=5)" suffix that reads like a
+footnote. This runner makes them impossible to miss, names each one, and can
+fail outright on them, so "everything passed" cannot quietly mean "everything
+that ran passed".
+
+Usage:
+  python3 scripts/run_tests.py             # run all, report skips prominently
+  python3 scripts/run_tests.py --strict    # exit non-zero if anything skipped
+  python3 scripts/run_tests.py -k iap      # only suites matching a substring
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+
+# Suites in rough order of how much they protect: flash safety first.
+SUITES = (
+    "test_iap_erase_guard.py",
+    "test_flash_switcher.py",
+    "test_flash_preflight.py",
+    "test_bootloader_updater.py",
+    "test_bootloader_power_entry.py",
+    "test_stock_dispatcher_power_handoff.py",
+    "test_stock_hybrid_power_hold_patch.py",
+    "test_stock_settings.py",
+    "test_stock_settings_diff.py",
+)
+
+RAN_RE = re.compile(r"^Ran (\d+) test", re.MULTILINE)
+SKIP_COUNT_RE = re.compile(r"skipped=(\d+)")
+# unittest -v prints:  test_name (module.Class.test_name) ... skipped 'reason'
+SKIP_LINE_RE = re.compile(r"^(\S+) \([^)]*\) \.\.\. skipped ['\"](.*)['\"]", re.MULTILINE)
+# the non-unittest suites print a bare:  skipped 'reason'
+BARE_SKIP_RE = re.compile(r"^skipped ['\"](.*)['\"]\s*$", re.MULTILINE)
+
+GREEN, RED, YELLOW, BOLD, DIM, RESET = (
+    ("\033[32m", "\033[31m", "\033[33m", "\033[1m", "\033[2m", "\033[0m")
+    if sys.stdout.isatty()
+    else ("", "", "", "", "", "")
+)
+
+
+class SuiteResult:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.ok = False
+        self.ran = 0
+        self.skipped: list[tuple[str, str]] = []
+        self.duration = 0.0
+        self.output = ""
+
+
+def run_suite(name: str) -> SuiteResult:
+    result = SuiteResult(name)
+    path = SCRIPTS / name
+    if not path.exists():
+        result.output = f"{name} does not exist"
+        return result
+
+    started = time.monotonic()
+    # -v so individual skip reasons are printed and can be attributed.
+    proc = subprocess.run(
+        [sys.executable, str(path), "-v"],
+        capture_output=True,
+        text=True,
+        cwd=SCRIPTS.parent,
+    )
+    result.duration = time.monotonic() - started
+    result.output = (proc.stdout or "") + (proc.stderr or "")
+    result.ok = proc.returncode == 0
+
+    ran = RAN_RE.search(result.output)
+    result.ran = int(ran.group(1)) if ran else 0
+    result.skipped = [(m.group(1), m.group(2)) for m in SKIP_LINE_RE.finditer(result.output)]
+    result.skipped += [("(whole suite)", m.group(1)) for m in BARE_SKIP_RE.finditer(result.output)]
+
+    # Suites that don't use unittest report their own totals; fall back to the
+    # aggregate count so the summary isn't silently zero for them.
+    if not result.ran:
+        legacy = re.search(r"^(\d+) tests? OK", result.output, re.MULTILINE)
+        result.ran = int(legacy.group(1)) if legacy else 0
+    if not result.skipped:
+        count = SKIP_COUNT_RE.search(result.output)
+        if count and int(count.group(1)):
+            result.skipped = [("(unnamed)", "reason not reported")] * int(count.group(1))
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--strict", action="store_true", help="exit non-zero if any test was skipped")
+    parser.add_argument("-k", metavar="SUBSTR", help="only run suites whose filename contains SUBSTR")
+    parser.add_argument("-v", "--verbose", action="store_true", help="print full output of failing suites")
+    args = parser.parse_args()
+
+    suites = [s for s in SUITES if not args.k or args.k in s]
+    if not suites:
+        print(f"no suite matches {args.k!r}", file=sys.stderr)
+        return 2
+
+    results = [run_suite(name) for name in suites]
+
+    print()
+    for r in results:
+        mark = f"{GREEN}PASS{RESET}" if r.ok else f"{RED}FAIL{RESET}"
+        skip_note = f"  {YELLOW}{len(r.skipped)} skipped{RESET}" if r.skipped else ""
+        print(f"  {mark}  {r.name:<44} {r.ran:>3} tests  {DIM}{r.duration:5.2f}s{RESET}{skip_note}")
+
+    failed = [r for r in results if not r.ok]
+    skipped = [(r, name, reason) for r in results for name, reason in r.skipped]
+    total_ran = sum(r.ran for r in results)
+
+    if failed and args.verbose:
+        for r in failed:
+            print(f"\n{RED}{'=' * 70}\n{r.name}\n{'=' * 70}{RESET}\n{r.output}")
+
+    print(f"\n{BOLD}{len(results) - len(failed)}/{len(results)} suites, {total_ran} tests{RESET}")
+
+    if skipped:
+        # The whole point: skips get a headline, not a suffix.
+        print(f"\n{YELLOW}{BOLD}⚠  {len(skipped)} TEST(S) DID NOT RUN{RESET}")
+        print(f"{YELLOW}   A skipped test is not a passing test. Most skips here mean a local")
+        print(f"   artifact is missing, which removes real coverage -- often the checks")
+        print(f"   that inspect built binaries rather than source text.{RESET}\n")
+        for r, name, reason in skipped:
+            print(f"   {DIM}{r.name}{RESET}  {name}\n      {YELLOW}{reason}{RESET}")
+        print(
+            f"\n   {DIM}Most are fixed by building first (make -C firmware/bootloader, etc.)\n"
+            f"   and providing archive/2C53T Firmware V1.2.0/.{RESET}"
+        )
+
+    if failed:
+        print(f"\n{RED}{BOLD}FAILED: {', '.join(r.name for r in failed)}{RESET}")
+        if not args.verbose:
+            print(f"{DIM}Re-run with -v for full output.{RESET}")
+        return 1
+    if skipped and args.strict:
+        print(f"\n{RED}{BOLD}--strict: failing because {len(skipped)} test(s) were skipped.{RESET}")
+        return 1
+    if not skipped:
+        print(f"{GREEN}All tests ran. No skips.{RESET}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_iap_erase_guard.py
+++ b/scripts/test_iap_erase_guard.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Behavioural test for the bootloader's IAP erase/write guard.
+
+WHY THIS EXISTS
+---------------
+The other flash-safety suites assert on the *text* of hid_iap_user.c -- they grep
+for the source strings a correct implementation is expected to contain. That
+catches a function being deleted, but it cannot tell correct logic from
+incorrect logic, because the strings are equally present in both.
+
+On 2026-08-11 that gap shipped a real regression through review. Commit
+11e4f76 gated *writes* on the *erase*-alignment predicate:
+
+    if (iap_erase_address_valid(address))   /* 2K sectors: (address & 2047) == 0 */
+
+but hid_flash.py sends an ADDR packet per 1KB block, and any part with >=256KB
+of flash uses 2K sectors. Half of every flash would have been NACKed -- the
+device would have failed on block 2 of 498. It passed a clean build, the full
+test suite, and a manual regression hunt, and was caught only when a
+contributor ran it on real hardware.
+
+So this test does not read the code. It EXECUTES it:
+
+  1. extracts the guard functions verbatim from hid_iap_user.c (no retyping --
+     if the source changes, this test runs the changed source),
+  2. compiles them for the host against a simulated flash array, with the
+     AT32 flash/USB/LCD calls stubbed,
+  3. drives realistic ADDR sequences through the real iap_address() and checks
+     what actually happened to the simulated flash.
+
+The property being defended is the one that matters: *every byte written must
+land on flash that was erased and not already programmed in this session.*
+
+VERIFIED BY MUTATION
+--------------------
+A test that never fails is worth nothing, so each assertion here was checked by
+reintroducing the bug it is supposed to catch. Seven mutations, seven caught:
+
+  M1  gate writes on erase alignment (the actual 11e4f76 bug)  -> caught
+  M2  erase every block instead of every sector                -> caught
+  M3  iap_init() forgets to clear the erase record             -> caught
+  M4  drop the sector-base match in same_erased_sector         -> caught
+  M5  drop the HID buffer alignment check                      -> caught
+  M6  skip the erase when one is required                      -> caught
+  M7  drop the write-window bounds check                       -> caught
+
+An eighth mutation -- making a failed erase respond ACK instead of NACK -- is
+NOT caught, and deliberately so: iap_erase_sector() returns IAP_FAILED only when
+iap_erase_required() is false, but it is called only when that same predicate is
+true. The else branch at the erase call site is unreachable by construction. If
+a future change makes it reachable, add a case here.
+
+Two of these (M3, M5) were missed by the first draft of this file, because the
+harness reset state itself instead of calling iap_init(), and because the
+alignment probe was also being rejected by a different check. That is the same
+"tested something other than the thing" failure the file exists to prevent, so:
+if you add an assertion, add the mutation that breaks it.
+
+Run: python3 scripts/test_iap_erase_guard.py
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+IAP_SOURCE = ROOT / "firmware" / "bootloader" / "src" / "hid_iap_user.c"
+VENDOR_HEADER = (
+    ROOT / "firmware" / "at32f403a_lib" / "middlewares" / "usbd_class" / "hid_iap" / "hid_iap_class.h"
+)
+
+# Functions lifted verbatim out of hid_iap_user.c, in dependency order.
+# iap_init() is included deliberately: the session-reset invariant (that a new
+# flash session must not inherit the previous session's erase record) lives in
+# iap_init(), so a harness that reset that state itself would be testing the
+# harness rather than the firmware.
+EXTRACTED_FUNCTIONS = (
+    "iap_erase_sector_base",
+    "iap_write_address_valid",
+    "iap_erase_required",
+    "iap_erase_sector",
+    "iap_init",
+    "iap_address",
+)
+
+# Stable ArteryTek SDK constants. The vendor lib is gitignored, so they are
+# duplicated here -- but when it *is* present, test_vendor_constants_match()
+# asserts these against it, so they cannot drift silently.
+SDK_CONSTANTS = {
+    "SECTOR_SIZE_1K": 0x400,
+    "SECTOR_SIZE_2K": 0x800,
+    "SECTOR_SIZE_4K": 0x1000,
+    "HID_IAP_BUFFER_LEN": 1024,
+}
+
+# Flash geometry under test: the 2C53T's 1MB AT32F403A, which selects 2K sectors.
+APP_ADDRESS = 0x08004000
+APP_END_ADDRESS = 0x08100000
+BLOCK = SDK_CONSTANTS["HID_IAP_BUFFER_LEN"]
+SECTOR = SDK_CONSTANTS["SECTOR_SIZE_2K"]
+SIM_FLASH_BYTES = 1024 * 1024
+
+
+def extract_c_function(source: str, name: str) -> str:
+    """Return the full text of a C function definition, by brace matching.
+
+    Deliberately dumb and exact: it finds the definition line, then walks braces.
+    No regex-based body parsing, so it cannot silently truncate a function.
+    """
+    pattern = re.compile(
+        r"^[A-Za-z_][A-Za-z0-9_ \t\*]*\b" + re.escape(name) + r"\s*\([^;]*?\)\s*\{",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(source)
+    if not match:
+        raise AssertionError(
+            f"could not find a definition of {name}() in {IAP_SOURCE.name}. "
+            "If it was renamed, update EXTRACTED_FUNCTIONS -- do not delete this test."
+        )
+    start = match.start()
+    depth = 0
+    for i in range(match.end() - 1, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : i + 1]
+    raise AssertionError(f"unbalanced braces while extracting {name}()")
+
+
+HARNESS_PROLOGUE = """
+/* Generated by scripts/test_iap_erase_guard.py -- do not edit by hand.
+   The guard functions below are copied VERBATIM from hid_iap_user.c. */
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define SECTOR_SIZE_1K %(SECTOR_SIZE_1K)#x
+#define SECTOR_SIZE_2K %(SECTOR_SIZE_2K)#x
+#define SECTOR_SIZE_4K %(SECTOR_SIZE_4K)#x
+#define HID_IAP_BUFFER_LEN %(HID_IAP_BUFFER_LEN)d
+#define IAP_ERASED_SECTOR_INVALID 0xFFFFFFFFu
+
+typedef enum { IAP_SUCCESS = 0, IAP_FAILED } iap_result_type;
+enum { IAP_STS_IDLE, IAP_STS_START, IAP_STS_ADDR, IAP_STS_DATA };
+#define IAP_ACK  0x00AAu
+#define IAP_NACK 0x00FFu
+#define IAP_CMD_ADDR 0x5AA2u
+
+typedef struct {
+  uint32_t flash_size;
+  uint32_t sector_size;
+  uint32_t flash_start_address;
+  uint32_t flash_end_address;
+  uint32_t app_address;
+  uint32_t iap_address;
+  uint32_t flag_address;
+  uint32_t fifo_length;
+  int      state;
+  uint8_t  iap_tx[64];
+} iap_info_type;
+
+iap_info_type iap_info;
+static uint32_t iap_write_start, iap_write_end;
+static uint8_t  iap_native_write;
+static uint32_t iap_erased_sector_address;
+
+/* Values iap_init() reads. sim_flash_size_kb is settable so the 1K-sector
+   branch (parts under 256KB) can be exercised through the real iap_init(). */
+static uint32_t sim_flash_size_kb = 1024;
+#define FLASH_SIZE_REG()      (sim_flash_size_kb)
+#define KB_TO_B(kb)           ((kb) * 1024u)
+#define FLASH_BASE            0x08000000u
+#define FLASH_APP_ADDRESS     %(APP_ADDRESS)#x
+#define FLASH_APP_END_ADDRESS %(APP_END_ADDRESS)#x
+
+/* ---- simulated flash ------------------------------------------------- */
+#define SIM_BASE  0x08000000u
+#define SIM_BYTES (1024u * 1024u)
+static uint8_t sim_erased[SIM_BYTES];   /* 1 = erased since session start   */
+static uint8_t sim_written[SIM_BYTES];  /* 1 = programmed since last erase  */
+static int violations;                  /* writes onto unerased/reprogrammed */
+static int destroyed;                   /* programmed bytes wiped by a later erase */
+static int last_response;               /* IAP_ACK / IAP_NACK               */
+
+/* Erases of a sector outside [iap_write_start, iap_write_end). The upgrade-flag
+   sector sits deliberately just below the app window, so it is not counted. */
+static int stray_erases;
+
+static void flash_unlock(void) {}
+static void flash_lock(void) {}
+static void flash_sector_erase(uint32_t addr)
+{
+  uint32_t base = addr - (addr %% iap_info.sector_size);
+  int in_window = (base >= iap_write_start && base + iap_info.sector_size <= iap_write_end);
+  if (!in_window && base != iap_info.flag_address) stray_erases++;
+  /* A real device would erase whatever it was told to; the simulator records
+     the trespass rather than corrupting its own memory. */
+  if (base < SIM_BASE || base + iap_info.sector_size > SIM_BASE + SIM_BYTES) return;
+  for (uint32_t i = 0; i < iap_info.sector_size; i++)
+    if (sim_written[(base - SIM_BASE) + i]) destroyed++;
+  memset(sim_erased  + (base - SIM_BASE), 1, iap_info.sector_size);
+  memset(sim_written + (base - SIM_BASE), 0, iap_info.sector_size);
+}
+static void iap_clear_upgrade_flag(void) { flash_sector_erase(iap_info.flag_address); }
+static void lcd_draw_iap_status(const char *s) { (void)s; }
+static void iap_respond(uint8_t *tx, uint16_t cmd, uint16_t res)
+{ (void)tx; (void)cmd; last_response = res; }
+
+/* Programs one HID block at the address the guard accepted, exactly as
+   iap_data_write() would, and flags any byte that was not erased first or
+   that is being programmed a second time. */
+static void sim_program_block(uint32_t addr)
+{
+  for (uint32_t i = 0; i < HID_IAP_BUFFER_LEN; i++) {
+    uint32_t off = (addr - SIM_BASE) + i;
+    if (!sim_erased[off] || sim_written[off]) { violations++; return; }
+    sim_written[off] = 1;
+  }
+}
+"""
+
+HARNESS_EPILOGUE = """
+/* ---- test driver ------------------------------------------------------ */
+
+/* Start a flash session the way the bootloader does: iap_start()/iap_idle()
+   both set state and call the REAL iap_init(). Nothing here resets
+   iap_erased_sector_address -- if iap_init() stops clearing it, the
+   session-reset test must fail, and that is the point. */
+static void session_reset(uint32_t flash_size_kb)
+{
+  memset(sim_erased, 0, sizeof sim_erased);
+  memset(sim_written, 0, sizeof sim_written);
+  violations = 0;
+  destroyed = 0;
+  stray_erases = 0;
+  sim_flash_size_kb = flash_size_kb;
+  iap_info.state = IAP_STS_START;
+  iap_init();
+}
+
+/* Same, but preserving simulated flash contents -- models a second flash
+   session on a device that was not power-cycled. */
+static void session_restart(void)
+{
+  iap_info.state = IAP_STS_START;
+  iap_init();
+}
+
+/* Feed one ADDR packet, in the on-wire big-endian layout iap_address() parses. */
+static int send_addr(uint32_t addr)
+{
+  uint8_t pkt[8];
+  pkt[0] = 0; pkt[1] = 0;
+  pkt[2] = (uint8_t)(addr >> 24); pkt[3] = (uint8_t)(addr >> 16);
+  pkt[4] = (uint8_t)(addr >> 8);  pkt[5] = (uint8_t)(addr);
+  last_response = 0;
+  iap_address(pkt, sizeof pkt);
+  return last_response == IAP_ACK;
+}
+
+#define FLASH_1MB_KB 1024u   /* -> 2K sectors */
+#define FLASH_128K_KB 128u   /* -> 1K sectors */
+
+int main(void)
+{
+  uint32_t base = %(APP_ADDRESS)#x;
+
+  /* 1. A full contiguous image, 1KB per ADDR, exactly as hid_flash.py sends it. */
+  session_reset(FLASH_1MB_KB);
+  printf("sector_size=%%u\\n", (unsigned)iap_info.sector_size);
+  int blocks = %(BLOCKS)d, nacks = 0, erases_seen = 0;
+  uint32_t prev_erased = IAP_ERASED_SECTOR_INVALID;
+  for (int b = 0; b < blocks; b++) {
+    uint32_t a = base + (uint32_t)b * HID_IAP_BUFFER_LEN;
+    if (!send_addr(a)) { nacks++; continue; }
+    if (iap_erased_sector_address != prev_erased) { erases_seen++; prev_erased = iap_erased_sector_address; }
+    sim_program_block(a);
+  }
+  printf("contiguous_nacks=%%d\\n", nacks);
+  printf("contiguous_erases=%%d\\n", erases_seen);
+  printf("contiguous_violations=%%d\\n", violations);
+  printf("contiguous_destroyed=%%d\\n", destroyed);
+
+  /* 2. Writing the upper half of a sector that was never erased (the shape a
+        partially-preserved settings hole would produce) must be refused. */
+  session_reset(FLASH_1MB_KB);
+  send_addr(base + iap_info.sector_size);              /* erase that sector   */
+  printf("partial_preserve_ack=%%d\\n",
+         send_addr(base + 4u * iap_info.sector_size + HID_IAP_BUFFER_LEN));
+
+  /* 3. Sub-block alignment must be refused -- in BOTH the unerased and the
+        already-erased case. The second is the one that isolates the alignment
+        check: the sector is erased, so an alignment-blind guard accepts it and
+        then programs a 1KB block straddling data already written at `base`. */
+  session_reset(FLASH_1MB_KB);
+  printf("misaligned_ack=%%d\\n", send_addr(base + 0x200u));
+
+  session_reset(FLASH_1MB_KB);
+  send_addr(base);                                     /* erases sector 0     */
+  sim_program_block(base);
+  printf("misaligned_in_erased_sector_ack=%%d\\n", send_addr(base + 0x200u));
+
+  /* 4. Out-of-window addresses must be refused, both ends. Both probes are
+        deliberately SECTOR-aligned: an unaligned probe gets refused by the
+        alignment logic no matter what the bounds check does, which would let a
+        missing bounds check pass unnoticed. */
+  session_reset(FLASH_1MB_KB);
+  printf("below_window_ack=%%d\\n", send_addr(base - 2u * iap_info.sector_size));
+  printf("above_window_ack=%%d\\n", send_addr(%(APP_END_ADDRESS)#x));
+  printf("stray_erases=%%d\\n", stray_erases);
+
+  /* 5. A fresh session must not inherit the previous session's erase record.
+        The restart goes through the real iap_init(); if that stops clearing
+        iap_erased_sector_address, this write into the already-programmed upper
+        half of sector 0 is wrongly accepted. */
+  session_reset(FLASH_1MB_KB);
+  send_addr(base);                                     /* erases sector 0     */
+  sim_program_block(base);                             /* ...and programs it  */
+  session_restart();                                   /* flash contents kept */
+  int ack5 = send_addr(base + HID_IAP_BUFFER_LEN);
+  if (ack5) sim_program_block(base + HID_IAP_BUFFER_LEN);
+  printf("stale_record_ack=%%d\\n", ack5);
+
+  /* 6. Same walk on a 1K-sector part (<256KB flash), where every block erases. */
+  session_reset(FLASH_128K_KB);
+  printf("sector_size_small=%%u\\n", (unsigned)iap_info.sector_size);
+  int nacks_1k = 0;
+  for (int b = 0; b < 64; b++) {
+    uint32_t a = base + (uint32_t)b * HID_IAP_BUFFER_LEN;
+    if (!send_addr(a)) nacks_1k++; else sim_program_block(a);
+  }
+  printf("sector1k_nacks=%%d\\n", nacks_1k);
+  printf("sector1k_violations=%%d\\n", violations);
+  printf("sector1k_destroyed=%%d\\n", destroyed);
+  return 0;
+}
+"""
+
+
+def build_harness(blocks: int) -> str:
+    source = IAP_SOURCE.read_text()
+    subs = dict(SDK_CONSTANTS)
+    subs.update(
+        {
+            "APP_ADDRESS": APP_ADDRESS,
+            "APP_END_ADDRESS": APP_END_ADDRESS,
+            "SECTOR": SECTOR,
+            "BLOCKS": blocks,
+        }
+    )
+    parts = [HARNESS_PROLOGUE % subs]
+    for name in EXTRACTED_FUNCTIONS:
+        parts.append(f"\n/* ---- verbatim from hid_iap_user.c: {name}() ---- */\n")
+        parts.append(extract_c_function(source, name))
+        parts.append("\n")
+    parts.append(HARNESS_EPILOGUE % subs)
+    return "".join(parts)
+
+
+class IapEraseGuardTests(unittest.TestCase):
+    results: dict[str, int] = {}
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not IAP_SOURCE.exists():
+            raise unittest.SkipTest(f"{IAP_SOURCE} not found")
+        cc = shutil.which("cc") or shutil.which("gcc") or shutil.which("clang")
+        if cc is None:
+            raise unittest.SkipTest("no host C compiler (cc/gcc/clang) available")
+
+        harness = build_harness(blocks=498)
+        with tempfile.TemporaryDirectory() as td:
+            csrc = Path(td) / "iap_guard_harness.c"
+            binary = Path(td) / "iap_guard_harness"
+            csrc.write_text(harness)
+            compile_proc = subprocess.run(
+                [cc, "-O1", "-std=c11", "-Wall", "-o", str(binary), str(csrc)],
+                capture_output=True,
+                text=True,
+            )
+            if compile_proc.returncode != 0:
+                raise AssertionError(
+                    "the guard harness failed to compile -- this usually means "
+                    "hid_iap_user.c gained a dependency the stubs don't provide.\n\n"
+                    + compile_proc.stderr
+                )
+            run_proc = subprocess.run([str(binary)], capture_output=True, text=True, timeout=60)
+            if run_proc.returncode != 0:
+                raise AssertionError(f"harness crashed:\n{run_proc.stderr}")
+
+        cls.results = {
+            k: int(v)
+            for k, _, v in (line.partition("=") for line in run_proc.stdout.strip().splitlines())
+            if v
+        }
+
+    # -- the regression that shipped through review on 2026-08-11 -------------
+
+    def test_every_block_of_a_full_image_is_accepted(self) -> None:
+        """498 x 1KB ADDR packets, 2K sectors: none may be NACKed.
+
+        The 11e4f76 guard NACKed 249 of these -- every address that was not
+        also sector-aligned -- which fails the flash on block 2.
+        """
+        self.assertEqual(
+            self.results["contiguous_nacks"],
+            0,
+            "the bootloader rejected ADDR packets during a normal contiguous "
+            "flash; a write-side guard is being gated on erase alignment again",
+        )
+
+    def test_each_sector_is_erased_exactly_once(self) -> None:
+        """498KB over 2K sectors is 249 erases -- one per sector, not per block.
+
+        Erasing per block would wipe the first half of each sector after it had
+        just been written.
+        """
+        self.assertEqual(self.results["contiguous_erases"], 249)
+
+    def test_no_byte_is_written_to_unerased_or_already_programmed_flash(self) -> None:
+        """The property that actually matters, checked against simulated flash."""
+        self.assertEqual(self.results["contiguous_violations"], 0)
+
+    def test_no_erase_destroys_data_written_earlier_in_the_session(self) -> None:
+        """An erase must never wipe bytes this session already programmed.
+
+        Erasing per 1KB block instead of per 2K sector passes an alignment
+        check and a NACK count, but silently wipes the first half of every
+        sector right after writing it.
+        """
+        self.assertEqual(
+            self.results["contiguous_destroyed"],
+            0,
+            "a sector erase wiped data programmed earlier in the same flash",
+        )
+
+    def test_the_geometry_under_test_is_the_real_one(self) -> None:
+        """Guard against the harness quietly testing the wrong flash layout."""
+        self.assertEqual(self.results["sector_size"], SECTOR)
+        self.assertEqual(self.results["sector_size_small"], SDK_CONSTANTS["SECTOR_SIZE_1K"])
+
+    # -- the invariants the guard is there to enforce -------------------------
+
+    def test_partially_preserved_sector_is_refused(self) -> None:
+        """Writing the upper half of a never-erased sector must NACK.
+
+        Until 52a61d1 this invariant lived only in the host tooling
+        (hid_flash.py validate_preserved_sectors); it is now enforced on-device.
+        """
+        self.assertEqual(self.results["partial_preserve_ack"], 0)
+
+    def test_sub_block_alignment_is_refused(self) -> None:
+        """An address that is not a whole HID buffer boundary must NACK.
+
+        Checked twice: once in a virgin sector, and once inside a sector that
+        was already erased -- the latter is what actually exercises the
+        alignment check, since the erase-record branch would otherwise accept
+        it and program a block straddling data already written.
+        """
+        self.assertEqual(self.results["misaligned_ack"], 0)
+        self.assertEqual(self.results["misaligned_in_erased_sector_ack"], 0)
+
+    def test_addresses_outside_the_write_window_are_refused(self) -> None:
+        """Both probes are sector-aligned, so only the bounds check can reject them."""
+        self.assertEqual(self.results["below_window_ack"], 0)
+        self.assertEqual(self.results["above_window_ack"], 0)
+
+    def test_no_sector_outside_the_app_window_is_ever_erased(self) -> None:
+        """Only the app window and the upgrade-flag sector may be erased.
+
+        The flag sector sits just below the app window by design; anything else
+        outside it means the bootloader is erasing itself or the stock image.
+        """
+        self.assertEqual(self.results["stray_erases"], 0)
+
+    def test_erase_record_does_not_survive_a_session_reset(self) -> None:
+        """iap_init() must clear iap_erased_sector_address.
+
+        Otherwise a new flash session could write into the second half of a
+        sector erased by the previous one, over data already programmed there.
+        """
+        self.assertEqual(self.results["stale_record_ack"], 0)
+
+    # -- the other flash geometry the SDK supports ---------------------------
+
+    def test_one_kilobyte_sector_parts_still_flash(self) -> None:
+        """Parts under 256KB use 1K sectors, where block size == sector size."""
+        self.assertEqual(self.results["sector1k_nacks"], 0)
+        self.assertEqual(self.results["sector1k_violations"], 0)
+        self.assertEqual(self.results["sector1k_destroyed"], 0)
+
+    # -- keep the duplicated SDK constants honest ----------------------------
+
+    def test_vendor_constants_match(self) -> None:
+        if not VENDOR_HEADER.exists():
+            self.skipTest(f"{VENDOR_HEADER.name} not present (at32f403a_lib is gitignored)")
+        header = VENDOR_HEADER.read_text()
+        for name, expected in SDK_CONSTANTS.items():
+            match = re.search(rf"#define\s+{name}\s+(0x[0-9A-Fa-f]+|\d+)", header)
+            self.assertIsNotNone(match, f"{name} not found in {VENDOR_HEADER.name}")
+            self.assertEqual(
+                int(match.group(1), 0),
+                expected,
+                f"{name} in the vendor SDK no longer matches this test's copy",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_stock_hybrid_power_hold_patch.py
+++ b/scripts/test_stock_hybrid_power_hold_patch.py
@@ -20,6 +20,20 @@ def load_builder():
 
 def main() -> int:
     builder = load_builder()
+
+    # Skip cleanly rather than dumping a FileNotFoundError traceback: the stock
+    # archive is not redistributable and the dispatcher must be built first, so
+    # a fresh clone legitimately has neither. Report it as a skip so it is
+    # counted as missing coverage, not mistaken for a broken test.
+    for label, path in (
+        ("stock archive image", builder.DEFAULT_STOCK),
+        ("stock dispatcher build", builder.DEFAULT_STOCK_DISPATCHER),
+    ):
+        if not path.exists():
+            print(f"skipped '{label} is not present: {path}'")
+            print("0 tests OK (1 skipped)")
+            return 0
+
     stock = builder.DEFAULT_STOCK.read_bytes()
     dispatcher = builder.DEFAULT_STOCK_DISPATCHER.read_bytes()
 


### PR DESCRIPTION
Follow-up to #16. Two testing gaps that let a real bootloader regression reach `main`'s doorstep, plus the documentation for both.

## Background

While verifying #16 I approved `11e4f76`, which gated **writes** on the **erase**-alignment predicate:

```c
if (iap_erase_address_valid(address))   /* 2K sectors: (address & 2047) == 0 */
```

`hid_flash.py` sends an ADDR packet per **1KB** block, and any part with ≥256KB of flash selects `SECTOR_SIZE_2K`. **Half of every flash would have been NACKed — failing on block 2 of 498.**

It passed a clean build, the full test suite, and an explicit regression hunt. @Komzpa caught it by running it on hardware and fixed it in `52a61d1`.

Neither of the two things that should have caught it could have.

## 1. `scripts/test_iap_erase_guard.py` — execute the guard, don't grep for it

The existing suites assert on the **text** of `hid_iap_user.c`. They cannot tell correct logic from incorrect logic, because the strings a correct implementation contains are equally present in a broken one — `test_bootloader_nacks_misaligned_erase_addresses` passed happily on the broken version.

This test instead:

1. lifts the guard functions **verbatim** out of `hid_iap_user.c` by brace matching — no retyping, so it always runs the current source;
2. compiles them for the host against a simulated flash array, with the AT32 flash/USB/LCD calls stubbed;
3. drives realistic ADDR sequences through the **real `iap_address()`** and checks what actually happened to the flash.

`iap_init()` is extracted too, deliberately: the session-reset invariant lives there, so a harness that reset that state itself would be testing the harness.

The property asserted is the one that matters: **every byte written must land on flash that was erased and not already programmed in this session.**

**Verified by mutation.** A test that never fails is worth nothing, so each assertion was checked by reintroducing the bug it should catch:

| Mutation | Result |
|---|---|
| M1 gate writes on erase alignment (**the actual `11e4f76` bug**) | caught |
| M2 erase every block instead of every sector | caught |
| M3 `iap_init()` forgets to clear the erase record | caught |
| M4 drop the sector-base match in `same_erased_sector` | caught |
| M5 drop the HID buffer alignment check | caught |
| M6 skip the erase when one is required | caught |
| M7 drop the write-window bounds check | caught |

An eighth — making a failed erase respond ACK — is **not** caught, and that's documented rather than papered over: `iap_erase_sector()` returns `IAP_FAILED` only when `iap_erase_required()` is false, but it's called only when that predicate is true, so the `else` at the call site is unreachable by construction. (That confirms the dead-branch note from the 28 July review.)

Worth admitting: **M3 and M5 were missed by the first draft** — the harness reset state itself instead of calling `iap_init()`, and the alignment probe was being rejected by a different check, so that assertion was vacuous. Which is exactly the failure this file exists to prevent, found by doing the mutation pass on it. Hence the rule now in CONTRIBUTING: if you add an assertion, add the mutation that breaks it.

Runs in ~0.1s, needs only a host C compiler, and skips cleanly without one.

## 2. `scripts/run_tests.py` — a skipped test is not a passing test

The other half of the miss. That review reported **"49 tests pass"** as clean. Five had been skipped for missing local artifacts — and one was `test_updater_binaries_gap_fill_stock_settings_page`, **the only test in the suite that inspects a real built binary** rather than source text. The highest-value check was silently absent from the number used to approve the change.

`unittest` renders skips as a quiet `(skipped=5)` suffix. This runner gives them a headline, names each one with its reason, and takes `--strict` to exit non-zero on any skip.

```
9/9 suites, 67 tests
All tests ran. No skips.
```

```
⚠  7 TEST(S) DID NOT RUN
   A skipped test is not a passing test. Most skips here mean a local
   artifact is missing, which removes real coverage -- often the checks
   that inspect built binaries rather than source text.

   test_bootloader_updater.py  test_updater_binaries_gap_fill_stock_settings_page
      firmware/bootloader_updater/build/bootloader_updater.bin has not been built
   ...
```

Also fixes `test_stock_hybrid_power_hold_patch.py`, which raised a bare `FileNotFoundError` traceback when the stock archive or dispatcher build was absent — it looked like a broken test rather than missing coverage, and made an otherwise-passing suite appear to fail on a fresh clone.

## Verification

- `python3 scripts/run_tests.py --strict` → **9/9 suites, 67 tests, 0 skips**, exit 0 (fully provisioned)
- Same on a bare tree → 9/9 suites, 7 skips named, `--strict` exits 1
- Mutation matrix above re-run against the committed tree
- No firmware behaviour is changed by this PR — tests, one test-only skip fix, and docs

## Notes

- `CONTRIBUTING.md` gains a "Running the tests" section covering the runner and the two habits: prefer tests that execute the logic, and prove a new test can fail before trusting it.
- Not addressed here, since it's @Komzpa's call and I asked in #16: `switch_firmware.py` now requires `uv` (`HID_FLASH_CMD = ["uv", "run", ...]` replaced `sys.executable`), undocumented, and the script now uses two different interpreters — preflight under `sys.executable`, flash under `uv run`. With `uv` off `PATH` the preflight passes and it dies at the moment it would write flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
