### PR TITLE
[WIP] Reconstruct editable GW1N-2 FPGA RTL

### DIFF
--- a/fpga/README.md
+++ b/fpga/README.md
@@ -1,0 +1,47 @@
+# FPGA reconstruction workspace
+
+This directory is the editable, evidence-tracked reconstruction of the FNIRSI
+2C53T scope FPGA. It is not the original vendor RTL.
+
+The target is the physically identified Gowin **GW1N-UV2 in QN48**, a member of
+the **GW1N-2** family. The stock configuration stream carries IDCODE
+`0x0120681B`. Package identity and device identity are established; board signal
+pin assignments are deliberately not copied here until the official QN48 table
+and board continuity results are integrated together.
+
+## Layout
+
+- `rtl/` — small, reviewed SystemVerilog blocks reconstructed from observed
+  behavior and structural evidence.
+- `sim/` — focused simulation testbenches for those blocks.
+- `tools/` and `tests/` — structural-comparison helpers and their tests.
+- `docs/provenance.md` — immutable stock inputs, hashes, and tool revisions.
+- `docs/reconstruction.md` — recovered block map, protocol facts, and unknowns.
+- `docs/verification.md` — proof levels and acceptance criteria.
+
+`rtl/capture_channel.sv` is currently a portable circular capture-memory
+primitive. Its unit test proves wrap, freeze, readback, and the disabled-capture
+negative control. It does **not** yet prove Gowin BSRAM inference, stock memory
+ordering, trigger behavior, timing closure, or hardware equivalence.
+
+## Quick local checks
+
+When Icarus Verilog and Verilator are installed:
+
+```sh
+iverilog -g2012 -s tb_capture_channel \
+  -o /tmp/tb_capture_channel \
+  fpga/rtl/capture_channel.sv fpga/sim/tb_capture_channel.sv
+vvp /tmp/tb_capture_channel
+verilator --lint-only --timing -Wall fpga/rtl/capture_channel.sv
+python3 -m unittest fpga/tests/test_netlist_verification.py
+```
+
+These are simulation and helper checks only. See
+[`docs/verification.md`](docs/verification.md) before making a stronger claim.
+
+## Safety
+
+All target experiments must load volatile **SRAM only**. Never write the FPGA's
+internal non-volatile flash: it contains the stock meter design and no verified
+recovery image exists. No file in this directory authorizes flashing hardware.

--- a/fpga/README.md
+++ b/fpga/README.md
@@ -29,8 +29,11 @@ the sample-clock/SPI-clock CDC protocol.
 
 The unit test proves wrap, freeze, readback, and the disabled-capture negative
 control. The BSRAM check proves the target synthesis netlist retains two `DPX9B`
-cells and rejects a register fallback. Neither check proves stock memory order,
-trigger behavior, timing closure, or hardware equivalence.
+cells and rejects a register fallback. The register, comparator, and divider
+blocks carry their own testbenches for the bench-grounded runtime writes,
+digital trigger level, opcode aliasing, and divided-tick contracts. None of
+these checks proves stock memory order, trigger behavior, timing closure, or
+hardware equivalence.
 
 ## Quick local checks
 
@@ -43,7 +46,9 @@ iverilog -g2012 -s tb_capture_channel \
 vvp /tmp/tb_capture_channel
 verilator --lint-only --timing -Wall \
   fpga/rtl/capture_channel.sv fpga/rtl/trigger_timebase.sv \
-  fpga/rtl/spi_runtime_interface.sv fpga/rtl/fnirsi_2c53t_top.sv
+  fpga/rtl/trigger_comparator.sv fpga/rtl/spi_runtime_interface.sv \
+  fpga/rtl/spi_control_registers.sv fpga/rtl/rate_divider.sv \
+  fpga/rtl/fnirsi_2c53t_top.sv
 python3 -m unittest fpga/tests/test_capture_bsram_mapping.py
 python3 -m unittest fpga/tests/test_netlist_verification.py
 ```

--- a/fpga/README.md
+++ b/fpga/README.md
@@ -35,6 +35,18 @@ digital trigger level, opcode aliasing, and divided-tick contracts. None of
 these checks proves stock memory order, trigger behavior, timing closure, or
 hardware equivalence.
 
+## Debug-clock hardware image
+
+`rtl/debugclk_hw_top.sv` plus `constraints/fnirsi_2c53t_qn48.cst` form the
+first buildable image for the exact GW1N-UV2/QN48 part. It uses only the six
+pins with netlist-grade evidence (runtime SPI, the IOR1B run line, and the
+clock-capable IOB7B pad as an MCU-driven debug sample clock) and feeds the
+capture path synthetic on-chip ramp and walking-one data, so no unproven ADC,
+clock, or board net is touched. `tools/build_debugclk_image.sh` reproduces the
+`.fs` build (synthesis, exact-part place-and-route, packing) with pinned tools;
+build products stay out of the tree. The image is for volatile SRAM loading
+only and has not yet been proven on hardware.
+
 ## Quick local checks
 
 When Icarus Verilog and Verilator are installed:
@@ -48,7 +60,7 @@ verilator --lint-only --timing -Wall \
   fpga/rtl/capture_channel.sv fpga/rtl/trigger_timebase.sv \
   fpga/rtl/trigger_comparator.sv fpga/rtl/spi_runtime_interface.sv \
   fpga/rtl/spi_control_registers.sv fpga/rtl/rate_divider.sv \
-  fpga/rtl/fnirsi_2c53t_top.sv
+  fpga/rtl/fnirsi_2c53t_top.sv fpga/rtl/debugclk_hw_top.sv
 python3 -m unittest fpga/tests/test_capture_bsram_mapping.py
 python3 -m unittest fpga/tests/test_netlist_verification.py
 ```

--- a/fpga/README.md
+++ b/fpga/README.md
@@ -19,10 +19,18 @@ and board continuity results are integrated together.
 - `docs/reconstruction.md` — recovered block map, protocol facts, and unknowns.
 - `docs/verification.md` — proof levels and acceptance criteria.
 
-`rtl/capture_channel.sv` is currently a portable circular capture-memory
-primitive. Its unit test proves wrap, freeze, readback, and the disabled-capture
-negative control. It does **not** yet prove Gowin BSRAM inference, stock memory
-ordering, trigger behavior, timing closure, or hardware equivalence.
+The top-level default has two 1024 x 8 raw capture stores. The portable
+registered-read/write split maps through the installed Yosys Gowin mapper to
+two `DPX9B` BSRAM primitives, one per channel. Each store needs 8192 bits; the
+mapper's 14-bit, byte-addressed BSRAM primitive has 18432 initialization bits,
+so the two stores need two primitives rather than one shared store. This is a
+resource-mapping result, not a claim about stock order, trigger behavior, or
+the sample-clock/SPI-clock CDC protocol.
+
+The unit test proves wrap, freeze, readback, and the disabled-capture negative
+control. The BSRAM check proves the target synthesis netlist retains two `DPX9B`
+cells and rejects a register fallback. Neither check proves stock memory order,
+trigger behavior, timing closure, or hardware equivalence.
 
 ## Quick local checks
 
@@ -33,7 +41,10 @@ iverilog -g2012 -s tb_capture_channel \
   -o /tmp/tb_capture_channel \
   fpga/rtl/capture_channel.sv fpga/sim/tb_capture_channel.sv
 vvp /tmp/tb_capture_channel
-verilator --lint-only --timing -Wall fpga/rtl/capture_channel.sv
+verilator --lint-only --timing -Wall \
+  fpga/rtl/capture_channel.sv fpga/rtl/trigger_timebase.sv \
+  fpga/rtl/spi_runtime_interface.sv fpga/rtl/fnirsi_2c53t_top.sv
+python3 -m unittest fpga/tests/test_capture_bsram_mapping.py
 python3 -m unittest fpga/tests/test_netlist_verification.py
 ```
 

--- a/fpga/constraints/fnirsi_2c53t_qn48.cst
+++ b/fpga/constraints/fnirsi_2c53t_qn48.cst
@@ -1,0 +1,14 @@
+// GW1N-UV2 QN48 physical constraints for debugclk_hw_top.
+//
+// Pin numbers are the audited UG171 QN48 package table as built into the
+// apicula agent/gw1n2-qn48-chipdb-20260815 database (GW1N-UV2QN48XF), NOT the
+// GW1N-1P5C QFN48XF proxy numbers.  IOB locations are the netlist-traced
+// runtime-SPI and run nets from the stock design.  Only these six nets have
+// continuity-grade or netlist-grade evidence; no other board pin may be added
+// here without the same standard of proof.
+IO_LOC "dbg_clk" 30;
+IO_LOC "run_enable" 46;
+IO_LOC "spi_cs_n" 34;
+IO_LOC "spi_sclk" 29;
+IO_LOC "spi_mosi" 35;
+IO_LOC "spi_so" 28;

--- a/fpga/docs/provenance.md
+++ b/fpga/docs/provenance.md
@@ -53,6 +53,34 @@ Pin every reproduction rather than following moving branch heads:
 | GW1N-2 place-and-route development | `DavidClawson/nextpnr`, `gw1n2` | `59c8f93a62ee17adc8d1c5d7f399697ffeb85c0f` |
 | exact GW1N-UV2/QN48 chipdb, packing, and the debug-clock image build | `Komzpa/apicula`, `agent/gw1n2-qn48-chipdb-20260815` | `d978cad` (atop `cea1618`) |
 
+## Debug-clock image reproduction
+
+Commit `25eb00b` is the first buildable exact-part debug-clock image. The
+recorded build used Yosys `0.66` (`git sha1 86f2ddebce7e98ce7cacc27e8a5c14cb53b51b51`) and Python `3.14.7`.
+
+| Artifact | SHA-256 |
+|---|---|
+| `apycula/GW1N-2.msgpack.xz` built at `Komzpa/apicula` `d978cad` | `3dc7b45d3c2eb1dc714a0e9bbbb55c2ab154d6a5bc6d546d8c947c8e452e285e` |
+| `debugclk_hw_top.fs` from the recorded build | `9c465d72a5cd5866b7c4b06baa87f10b2e4e3c5f965f09c1518fa08c47d10751` |
+
+Reproduce it with (all four tools from the pinned revisions in the table
+above):
+
+```sh
+APICULA_PYTHON=<python with apycula installed -e at d978cad> \
+NEXTPNR=<nextpnr-himbaechel built from DavidClawson/nextpnr gw1n2 59c8f93a> \
+NEXTPNR_SRC=<that nextpnr source tree> \
+BBASM=<bba/bbasm from the same nextpnr build> \
+OUT=<empty build dir> \
+sh fpga/tools/build_debugclk_image.sh
+sha256sum "$OUT"/debugclk_hw_top.fs
+```
+
+At the pinned baseline the command used the exact-part Apicula checkout
+providing `apycula/GW1N-2.msgpack.xz`; without that chipdb,
+`nextpnr-himbaechel` reports `No package for partnumber GW1N-UV2QN48XFC6/I5`.
+Keep the hash tied to this commit: later RTL changes change the `.fs` image.
+
 The chipdb build requires Gowin EDA device data for `GW1N-1P5C`:
 `GW1N-1P5C.fse`, `.dat`, and `.tm`. Those vendor inputs are not checked in.
 Without the exact generated `GW1N-2.msgpack.xz`, a fresh unpack is blocked and

--- a/fpga/docs/provenance.md
+++ b/fpga/docs/provenance.md
@@ -51,6 +51,7 @@ Pin every reproduction rather than following moving branch heads:
 | stock unpack and GW1N-2 chipdb baseline | `DavidClawson/apicula`, `gw1n2-build` | `2987a6a323107e54d02b2d47a452f0fd09c95a07` |
 | GW1N-2 pinout/IO development | `DavidClawson/apicula`, `gw1n2-io` | `cf5ab40d203a3f79dc233bdd8000b7c5fc2dfacb` |
 | GW1N-2 place-and-route development | `DavidClawson/nextpnr`, `gw1n2` | `59c8f93a62ee17adc8d1c5d7f399697ffeb85c0f` |
+| exact GW1N-UV2/QN48 chipdb, packing, and the debug-clock image build | `Komzpa/apicula`, `agent/gw1n2-qn48-chipdb-20260815` | `d978cad` (atop `cea1618`) |
 
 The chipdb build requires Gowin EDA device data for `GW1N-1P5C`:
 `GW1N-1P5C.fse`, `.dat`, and `.tm`. Those vendor inputs are not checked in.

--- a/fpga/docs/provenance.md
+++ b/fpga/docs/provenance.md
@@ -1,0 +1,71 @@
+# Provenance and reproducibility
+
+## Immutable stock inputs
+
+The canonical source is the stock MCU application archive, not a generated
+Verilog file:
+
+| Artifact | Size | SHA-256 | Provenance |
+|---|---:|---|---|
+| `APP_2C53T_V1.2.0_251015.bin` | 751232 bytes | `a17c5c35c97bb898f15672a1747bc1041d8ed507c16999ddba0d1e4e2ec0c760` | FNIRSI V1.2.0 application archive |
+| raw FPGA slice | 115638 bytes | `5a0e73384e496bdb3b3d591b852bec2e806e70cbc71439c9829695324efd5c3b` | exact bytes at file offset `0x4AD19` in the archive |
+
+Reproduce the second hash without creating a file:
+
+```sh
+dd if='APP_2C53T_V1.2.0_251015.bin' bs=1 \
+  skip=$((0x4AD19)) count=115638 status=none | sha256sum
+```
+
+The stream header identifies the device family with IDCODE `0x0120681B`.
+Physical inspection identifies the installed part as `GW1N-UV2`, package
+`QN48`; `GW1N-UV2` uses the GW1N-2 fabric/tool device.
+
+The stock payload and generated netlist may retain FNIRSI rights. Their presence
+or reproducibility does not grant a redistribution license. Keep provenance and
+licensing separate.
+
+## Published reference artifacts
+
+The immutable published reference is
+`DavidClawson/gw1n2-apicula@7e44f773ccdabe8cce16b13d85b491e1321c8949`:
+
+| Path at that commit | Size | SHA-256 | Meaning |
+|---|---:|---|---|
+| `tools/m5/scope.fs` | 925842 bytes | `f2fde7b6458bacb4d8d607e97277531e36823a715bcb2bee11380a082742fd44` | ASCII-form configuration stream; decoded payload matches the raw FPGA-slice hash above |
+| `tools/m5/scope_unpacked.v` | 2179558 bytes | `982a94ed69cadb16b45a18a06bc3412895a933f6e753f3260a16a1c8aca9ee32` | Apicula-generated primitive netlist |
+
+`scope_unpacked.v` is staged evidence, not source truth. It is a single anonymous
+top-level fabric netlist made of Gowin primitives. It preserves useful
+connectivity, LUT initialization, memories, and I/O-cell structure, but not the
+original hierarchy, names, comments, intent, clock constraints, or HDL. Some
+primitive inputs and PLL semantics are not recovered. Editing it would create a
+gate patch, not maintainable reconstructed RTL.
+
+## Tool revisions
+
+Pin every reproduction rather than following moving branch heads:
+
+| Purpose | Repository branch | Commit |
+|---|---|---|
+| stock unpack and GW1N-2 chipdb baseline | `DavidClawson/apicula`, `gw1n2-build` | `2987a6a323107e54d02b2d47a452f0fd09c95a07` |
+| GW1N-2 pinout/IO development | `DavidClawson/apicula`, `gw1n2-io` | `cf5ab40d203a3f79dc233bdd8000b7c5fc2dfacb` |
+| GW1N-2 place-and-route development | `DavidClawson/nextpnr`, `gw1n2` | `59c8f93a62ee17adc8d1c5d7f399697ffeb85c0f` |
+
+The chipdb build requires Gowin EDA device data for `GW1N-1P5C`:
+`GW1N-1P5C.fse`, `.dat`, and `.tm`. Those vendor inputs are not checked in.
+Without the exact generated `GW1N-2.msgpack.xz`, a fresh unpack is blocked and
+must not be reported as reproduced.
+
+The expected unpack command at the pinned baseline is:
+
+```sh
+PYTHONPATH=/path/to/apicula python3 -m apycula.gowin_unpack \
+  -d GW1N-2 scope.fs -o scope_unpacked.v
+sha256sum scope_unpacked.v
+```
+
+An exact byte hash is the strongest reproduction result. If emission order
+changes across Python or Apicula revisions, use the repository's structural
+verifier and report only structural equality; never silently substitute that
+for a byte-identical result.

--- a/fpga/docs/reconstruction.md
+++ b/fpga/docs/reconstruction.md
@@ -24,12 +24,40 @@ serial `SO` output. The exact read start address, stride, lane order, and status
 semantics remain unproven. The SRAM-only R1 validator pattern is the intended
 hardware oracle for those details.
 
+### Runtime writes and decoded register facts
+
+- The stock post-configuration arm sequence is five two-byte CS-low write
+  frames: `01 08`, `02 03`, `06 00`, `07 00`, `08 AD`.
+- Register `0x08` is the trigger level in ADC codes, and the trigger comparator
+  is digital and post-ADC. This was bench-proven in both directions
+  (2026-08-14): quiet noise below stock's armed `0xAD` level produces no
+  trigger completions, level `0x37` inside the noise band triggers on the noise
+  itself, and restoring `0xAD` stops it again.
+- Only the low five opcode bits are decoded: reads `0x20`–`0x3F` alias
+  `0x00`–`0x1F` exactly, including live channel data on `0x24`/`0x25`
+  (exhaustive sweep, 2026-08-14). Extending that decode to write selects is a
+  hypothesis, not a bench result.
+- A byte-exact replay of the full stock configuration and arm traffic
+  (2026-08-14) left the capture rate at its slow default, so registers
+  `0x01/0x02/0x06/0x07/0x08` are unlikely to be the sample-rate control. That
+  control is structurally traced to a counter gating the `BSRAM_1/2` write
+  clock, with a load path from the SPI receiver bank (`gw1n2-apicula` M12);
+  its register address is unknown.
+- Default capture-rate measurements disagree in detail while agreeing on the
+  regime: 2026-08-15 bench gives ~1.07 kS/s (1024-sample fill ≈ 0.96 s), the
+  2026-08-14 methods gave ~2.4–2.7 kS/s, and stock sustains ~23× faster. The
+  spread is unresolved; this RTL encodes no clock frequency and takes no
+  position on it.
+
 ## Recovered block map
 
 | Evidence block | Recovered role | Proposed editable boundary | Confidence |
 |---|---|---|---|
 | SPI/SSPI input and `SO` mux | shifts commands/control and selects channel/status readback | `runtime_spi_frontend` | high structure, incomplete protocol |
 | SPI-fed control flop plus run inputs | participates in capture enable/re-arm | `capture_control` | medium-high; polarity and complete register map unknown |
+| SPI-loaded control register bank | commits the five observed two-byte write frames | `spi_control_registers` | high frame shape; only `0x08` semantics decoded |
+| post-ADC comparator against register `0x08` | digital trigger level in ADC codes | `trigger_comparator` | high mechanism (bench, both directions); edge, source, hysteresis, holdoff unknown |
+| counter-gated `BSRAM_1/2` write clock with SPI-side load | programmable sample-rate divider | `rate_divider` | medium structure (M12); divisor address and value unknown |
 | large counter/control cone | sequences capture and read addresses | `capture_sequencer` | medium |
 | `BSRAM_0` at `R10C2` | raw CH1 capture store on PLL clock | `capture_channel` instance | high role, byte mapping unknown |
 | `BSRAM_3` at `R10C17` | raw CH2 capture store on PLL clock | `capture_channel` instance | high role, byte mapping unknown |
@@ -53,6 +81,9 @@ Counts help detect gross drift; they do not prove behavior.
 | channel reads use full 1026-byte `0x04`/`0x05` windows | stock capture plus firmware bench path | high framing; status and sample ordering unresolved |
 | `BSRAM_0/3` are raw CH1/CH2 stores | ADC-to-BSRAM and BSRAM-to-`SO` structural traces | high structural role; exact lane mapping unknown |
 | `BSRAM_1/2` are a slow/computed path | SDR inputs, gated clock, shared counter, read-modify-write | medium; decimation/roll meaning is a hypothesis |
+| SPI register `0x08` is the digital post-ADC trigger level; stock arms `0xAD` | two-way bench A/B at levels `0xAD` and `0x37` (2026-08-14) | high mechanism and encoding; polarity, hysteresis, holdoff unknown |
+| opcode decode uses only the low five bits | exhaustive read-opcode sweep, exact `0x20`–`0x3F` aliasing | high for reads; write selects by declared extension only |
+| the capture-rate control is an SPI-reachable counter on the `BSRAM_1/2` clock gate | M12 structural trace; byte-exact arm replay stays slow | medium; register address and divisor encoding unknown |
 | handwritten `capture_channel` matches stock | unit simulation only | low equivalence confidence; no synthesis/P&R/hardware proof |
 
 ## Current editable RTL
@@ -66,6 +97,15 @@ This block is a clean implementation hypothesis, not a transliteration of a
 specific `BSRAM_*` macro. The next integration layer must decide how trigger,
 freeze, read-pointer translation, channel muxing, and CDC are represented.
 
+`spi_control_registers.sv` commits the observed two-byte write frames at the CS
+boundary, with reset defaults equal to the stock arm-sequence values.
+`trigger_comparator.sv` implements the bench-proven digital post-ADC level
+comparison against register `0x08`, with rising-edge crossing as its declared
+local contract. `rate_divider.sv` reconstructs the M12 counter-gate shape as an
+SPI-loadable sample-rate divider; its load select is an explicit placeholder
+address, and the top exports the divided tick instead of instantiating the
+`BSRAM_1/2` store pair because that record's function is still a hypothesis.
+
 ## Explicit unknowns
 
 - complete runtime opcode and writable-register map;
@@ -74,7 +114,12 @@ freeze, read-pointer translation, channel muxing, and CDC are represented.
   continuity (proxy-package pin numbers are not acceptable);
 - raw sample bit order, DDR lane meaning, signedness, first address, and wrap;
 - meaning of all three status bytes in `0x04`/`0x05` reads;
-- trigger FSM, threshold encoding, pre/post-trigger split, and re-arm sequence;
+- trigger edge and source selection, hysteresis, holdoff, pre/post-trigger
+  split, and the re-arm sequence (the threshold register `0x08` and its
+  ADC-code encoding are now decoded);
+- the sample-rate divisor register address and encoding (the `rate_divider`
+  load select is an explicit placeholder);
+- semantics of the stored raw registers `0x01`, `0x02`, `0x06`, and `0x07`;
 - whether `BSRAM_1/2` implement decimation, min/max, roll mode, or another
   computed record;
 - PLL parameters, clock frequencies, phase relationships, and timing constraints;

--- a/fpga/docs/reconstruction.md
+++ b/fpga/docs/reconstruction.md
@@ -37,17 +37,28 @@ hardware oracle for those details.
   `0x00`–`0x1F` exactly, including live channel data on `0x24`/`0x25`
   (exhaustive sweep, 2026-08-14). Extending that decode to write selects is a
   hypothesis, not a bench result.
-- A byte-exact replay of the full stock configuration and arm traffic
-  (2026-08-14) left the capture rate at its slow default, so registers
-  `0x01/0x02/0x06/0x07/0x08` are unlikely to be the sample-rate control. That
-  control is structurally traced to a counter gating the `BSRAM_1/2` write
-  clock, with a load path from the SPI receiver bank (`gw1n2-apicula` M12);
-  its register address is unknown.
-- Default capture-rate measurements disagree in detail while agreeing on the
-  regime: 2026-08-15 bench gives ~1.07 kS/s (1024-sample fill ≈ 0.96 s), the
-  2026-08-14 methods gave ~2.4–2.7 kS/s, and stock sustains ~23× faster. The
-  spread is unresolved; this RTL encodes no clock frequency and takes no
-  position on it.
+- The 2026-08-15 maintainer sweep (DavidClawson/OpenScope-2C53T PR #24)
+  identifies register `0x01` as the rate select; the counter gating the
+  `BSRAM_1/2` write clock with an SPI-side load path (M12) is the structural
+  candidate it loads. A 2026-08-16 attempt to reproduce the ladder in the
+  published `m_divider.py` micro-sim was inconclusive: the extracted gates sit
+  flat because the SPI/arm clear and clock nets are undriven long-wire
+  branches in the unpacked netlist, so the ladder rests on the bench sweep.
+- The ~1.07 kS/s and earlier ~2.4–2.7 kS/s measurements were both artifacts of
+  mode `0x08`: its zero-crossing count is tone-independent and triggered reads
+  can be torn. They are not sample-rate measurements and do not imply a hidden
+  23× divider. Stock almost certainly runs `0x0F`, retiring that mystery.
+
+| `reg 0x01` | Measured rate | Rate vs `0x0F` | Divisor vs `0x0F` |
+|---|---|---|---|
+| `0x0F` | ≈30 kS/s | 1× | 1 (stock candidate) |
+| `0x0E` | ≈60 kS/s | 2× | /2 |
+| `0x0D` | ≈150 kS/s | 5× | /5 |
+| `0x0C` | ≈300 kS/s | 10× | /10 |
+| `0x0B` | ≈500–600 kS/s (indicative) | ≈20× | /20 |
+| `0x0A` | ≈1 MS/s (indicative) | ≈33× | /33 |
+| `0x10` / `0x1F` | ≈15 kS/s | 0.5× | ×2 |
+| `0x08` | not a uniform rate | — | legacy slow default kept; suspected decimation/peak-detect mode, not a ladder point |
 
 ## Recovered block map
 
@@ -57,7 +68,7 @@ hardware oracle for those details.
 | SPI-fed control flop plus run inputs | participates in capture enable/re-arm | `capture_control` | medium-high; polarity and complete register map unknown |
 | SPI-loaded control register bank | commits the five observed two-byte write frames | `spi_control_registers` | high frame shape; only `0x08` semantics decoded |
 | post-ADC comparator against register `0x08` | digital trigger level in ADC codes | `trigger_comparator` | high mechanism (bench, both directions); edge, source, hysteresis, holdoff unknown |
-| counter-gated `BSRAM_1/2` write clock with SPI-side load | programmable sample-rate divider | `rate_divider` | medium structure (M12); divisor address and value unknown |
+| counter-gated `BSRAM_1/2` write clock with SPI-side load | `reg 0x01` low-nibble rate ladder (`0x0F`..`0x0A`, plus `0x10`/`0x1F` special 15 kS/s) | `rate_divider` | medium structure (M12); `0x08` is still the observed slow-default, but its exact stock semantic is unresolved |
 | large counter/control cone | sequences capture and read addresses | `capture_sequencer` | medium |
 | `BSRAM_0` at `R10C2` | raw CH1 capture store on PLL clock | `capture_channel` instance | high role, byte mapping unknown |
 | `BSRAM_3` at `R10C17` | raw CH2 capture store on PLL clock | `capture_channel` instance | high role, byte mapping unknown |
@@ -83,7 +94,7 @@ Counts help detect gross drift; they do not prove behavior.
 | `BSRAM_1/2` are a slow/computed path | SDR inputs, gated clock, shared counter, read-modify-write | medium; decimation/roll meaning is a hypothesis |
 | SPI register `0x08` is the digital post-ADC trigger level; stock arms `0xAD` | two-way bench A/B at levels `0xAD` and `0x37` (2026-08-14) | high mechanism and encoding; polarity, hysteresis, holdoff unknown |
 | opcode decode uses only the low five bits | exhaustive read-opcode sweep, exact `0x20`–`0x3F` aliasing | high for reads; write selects by declared extension only |
-| the capture-rate control is an SPI-reachable counter on the `BSRAM_1/2` clock gate | M12 structural trace; byte-exact arm replay stays slow | medium; register address and divisor encoding unknown |
+| the capture-rate control is an SPI-reachable counter on the `BSRAM_1/2` clock gate, selected by `reg 0x01` | ladder: 2026-08-15 PR #24 bench sweep; counter shape: M12 structural trace (micro-sim reproduction inconclusive — gates flat on undriven long-wire nets) | medium; `0x08` slow-default semantics remain unresolved |
 | handwritten `capture_channel` matches stock | unit simulation only | low equivalence confidence; no synthesis/P&R/hardware proof |
 
 ## Current editable RTL
@@ -98,13 +109,16 @@ specific `BSRAM_*` macro. The next integration layer must decide how trigger,
 freeze, read-pointer translation, channel muxing, and CDC are represented.
 
 `spi_control_registers.sv` commits the observed two-byte write frames at the CS
-boundary, with reset defaults equal to the stock arm-sequence values.
+boundary, with reset defaults equal to the stock arm-sequence values. The raw
+`0x01` byte is also the rate-divider select; the old out-of-map divisor
+placeholder has been retired.
 `trigger_comparator.sv` implements the bench-proven digital post-ADC level
 comparison against register `0x08`, with rising-edge crossing as its declared
 local contract. `rate_divider.sv` reconstructs the M12 counter-gate shape as an
-SPI-loadable sample-rate divider; its load select is an explicit placeholder
-address, and the top exports the divided tick instead of instantiating the
-`BSRAM_1/2` store pair because that record's function is still a hypothesis.
+SPI-loadable sample-rate divider using the measured `0x01` ladder; its absolute
+base clock remains parameterized and the top exports the divided tick instead
+of instantiating the `BSRAM_1/2` store pair because that record's function is
+still a hypothesis.
 
 ## Explicit unknowns
 
@@ -117,8 +131,8 @@ address, and the top exports the divided tick instead of instantiating the
 - trigger edge and source selection, hysteresis, holdoff, pre/post-trigger
   split, and the re-arm sequence (the threshold register `0x08` and its
   ADC-code encoding are now decoded);
-- the sample-rate divisor register address and encoding (the `rate_divider`
-  load select is an explicit placeholder);
+- the exact stock preload convention for `reg 0x01` mode `0x08` and any
+  remaining selection source behind it;
 - semantics of the stored raw registers `0x01`, `0x02`, `0x06`, and `0x07`;
 - whether `BSRAM_1/2` implement decimation, min/max, roll mode, or another
   computed record;

--- a/fpga/docs/reconstruction.md
+++ b/fpga/docs/reconstruction.md
@@ -1,0 +1,87 @@
+# Reconstruction map
+
+This map separates recovered facts from proposed editable boundaries. Names in
+`fpga/rtl/` are ours; they are not recovered vendor module names.
+
+## Runtime interface
+
+The scope MCU reads one channel per SPI transaction while chip select remains
+low for the full **1026-byte** window:
+
+| Byte clocks | MOSI | MISO meaning |
+|---|---|---|
+| 0 | `0x04` for CH1 or `0x05` for CH2 | first status/marker byte |
+| 1..2 | `0xFF` | two more status bytes |
+| 3..1025 | `0xFF` | 1023 sample bytes |
+
+The firmware duplicates sample 1022 into its 1024th UI slot; the wire frame
+contains 1023 samples, not 1024. The `0x05` transaction must never be shortened:
+a short `0x05` frame collides with the Gowin `ERASE_SRAM` configuration opcode,
+whereas the 1026-byte shape is the observed CH2 read.
+
+Structural tracing places all four BSRAM read paths behind one mux onto the
+serial `SO` output. The exact read start address, stride, lane order, and status
+semantics remain unproven. The SRAM-only R1 validator pattern is the intended
+hardware oracle for those details.
+
+## Recovered block map
+
+| Evidence block | Recovered role | Proposed editable boundary | Confidence |
+|---|---|---|---|
+| SPI/SSPI input and `SO` mux | shifts commands/control and selects channel/status readback | `runtime_spi_frontend` | high structure, incomplete protocol |
+| SPI-fed control flop plus run inputs | participates in capture enable/re-arm | `capture_control` | medium-high; polarity and complete register map unknown |
+| large counter/control cone | sequences capture and read addresses | `capture_sequencer` | medium |
+| `BSRAM_0` at `R10C2` | raw CH1 capture store on PLL clock | `capture_channel` instance | high role, byte mapping unknown |
+| `BSRAM_3` at `R10C17` | raw CH2 capture store on PLL clock | `capture_channel` instance | high role, byte mapping unknown |
+| `BSRAM_1` at `R10C5` and `BSRAM_2` at `R10C14` | shared SDR/computed path on a gated fabric clock; read-modify-write evidence | `slow_capture_path` | medium structure, function only a hypothesis |
+| registered output from capture cone | likely data-ready/buffer status | `capture_status` | medium; board net and polarity need proof |
+| PLL/global-clock network | clocks DDR input and capture memories | `clocking` wrapper | high existence, incomplete PLL configuration |
+
+The generated reference contains 847 LUT4 primitives, 192 ALUs, four BSRAMs,
+15 IDDRCs, and one ODDRC under the current raw primitive-inventory oracle.
+Flip-flop totals depend on whether unpacker artifacts are excluded, so the
+verifier reports each primitive class instead of publishing one ambiguous sum.
+Counts help detect gross drift; they do not prove behavior.
+
+## Evidence confidence ledger
+
+| Claim | Evidence | Confidence / limit |
+|---|---|---|
+| target is GW1N-UV2/QN48, GW1N-2 family | physical marking, official device family, stream IDCODE | high identity; no board-net assignment implied |
+| stock payload is the 115638-byte slice at `0x4AD19` | byte extraction and SHA-256 reproduction | high for the named archive only |
+| `scope_unpacked.v` represents that stock design | pinned Apicula artifact and immutable hash | high provenance; generated and partly incomplete netlist |
+| channel reads use full 1026-byte `0x04`/`0x05` windows | stock capture plus firmware bench path | high framing; status and sample ordering unresolved |
+| `BSRAM_0/3` are raw CH1/CH2 stores | ADC-to-BSRAM and BSRAM-to-`SO` structural traces | high structural role; exact lane mapping unknown |
+| `BSRAM_1/2` are a slow/computed path | SDR inputs, gated clock, shared counter, read-modify-write | medium; decimation/roll meaning is a hypothesis |
+| handwritten `capture_channel` matches stock | unit simulation only | low equivalence confidence; no synthesis/P&R/hardware proof |
+
+## Current editable RTL
+
+`capture_channel.sv` models one circular sample memory with independent write and
+read clocks. It intentionally exposes physical addresses and keeps ordering
+policy above the primitive. It has no memory reset because clearing a BRAM array
+would distort inference and is not supported by the recovered evidence.
+
+This block is a clean implementation hypothesis, not a transliteration of a
+specific `BSRAM_*` macro. The next integration layer must decide how trigger,
+freeze, read-pointer translation, channel muxing, and CDC are represented.
+
+## Explicit unknowns
+
+- complete runtime opcode and writable-register map;
+- exact polarity and board ownership of run, co-enable, and data-ready signals;
+- QN48 board-pin mapping until official package data is reconciled with board
+  continuity (proxy-package pin numbers are not acceptable);
+- raw sample bit order, DDR lane meaning, signedness, first address, and wrap;
+- meaning of all three status bytes in `0x04`/`0x05` reads;
+- trigger FSM, threshold encoding, pre/post-trigger split, and re-arm sequence;
+- whether `BSRAM_1/2` implement decimation, min/max, roll mode, or another
+  computed record;
+- PLL parameters, clock frequencies, phase relationships, and timing constraints;
+- CDC behavior between sample, control-SPI, and readout domains;
+- DMM and signal-generator islands and their interfaces;
+- fit, routing, timing, power, analog fidelity, and hardware equivalence of the
+  handwritten RTL.
+
+Do not fill these gaps with convenient pin numbers or names from another Gowin
+package. Record the evidence gap and add a falsifiable test.

--- a/fpga/docs/verification.md
+++ b/fpga/docs/verification.md
@@ -1,0 +1,51 @@
+# Verification levels
+
+Use the weakest claim supported by the strongest completed row. Passing a lower
+row never implies a higher one.
+
+| Level | Required evidence | What may be claimed |
+|---|---|---|
+| Unit simulation | deterministic testbench pass plus a negative control for each editable block | the modeled RTL behavior passes those cases |
+| Reference parse | expected input hashes and successful parse of the generated stock netlist | the named immutable artifact was read successfully |
+| Structural match | both input hashes, identical canonical named connectivity, and matching primitive inventory | equality under that structural oracle only |
+| Synthesis | pinned Yosys/tool revision, exact RTL commit, warnings reviewed, resource report retained | the RTL synthesizes for the selected device model |
+| Place and route | exact GW1N-2 device/package, constraints, pinned nextpnr or Gowin EDA revision, routed design, and timing report | the candidate fits and meets the reported constraints |
+| Bitstream round-trip | immutable input/output hashes and unpack/repack comparison | the tested encoding round-trips under the stated oracle |
+| Hardware proof | exact board identity; SRAM-only load receipt; DONE/status readback; observed `0x04`/`0x05` frames; known waveform stimulus; negative control; reboot restores stock | only the exercised target behavior works on that board |
+
+## Structural verifier
+
+`tools/verify_structural_netlists.py` compares Yosys JSON after canonicalizing
+named connectivity. It requires both SHA-256 values and reports primitive
+inventories. A pass deliberately excludes behavioral, timing, placement,
+routing, and bitstream equivalence.
+
+Example:
+
+```sh
+python3 fpga/tools/verify_structural_netlists.py \
+  --archived /path/to/reference/scope_unpacked.v \
+  --archived-sha256 982a94ed69cadb16b45a18a06bc3412895a933f6e753f3260a16a1c8aca9ee32 \
+  --fresh /path/to/fresh/scope_unpacked.v \
+  --fresh-sha256 <fresh-sha256>
+```
+
+If Yosys is absent, this level is blocked. A matching line count or primitive
+count is not a substitute.
+
+## Hardware acceptance for a reconstructed capture path
+
+Minimum acceptance is one named FNIRSI 2C53T board, loaded to volatile SRAM only:
+
+1. Read back the GW1N-2 IDCODE `0x0120681B` and record board and loader identity.
+2. Load the exact candidate to SRAM; record its hash and DONE/status result.
+3. Drive a known DC level and periodic waveform into CH1 and CH2 separately.
+4. Capture full 1026-byte `0x04` and `0x05` transactions and retain raw bytes.
+5. Prove channel isolation, sample ordering, wrap, trigger/re-arm, and repeated
+   acquisition against the known stimulus.
+6. Negative control: disabling capture must leave memory and readiness stable;
+   changing only CH1 must not produce the same change in CH2.
+7. Power-cycle and prove the stock non-volatile design returns.
+
+LCD traces, a green DONE pin, or one plausible buffer are supporting evidence,
+not end-to-end proof. No NV-flash write belongs in this procedure.

--- a/fpga/rtl/capture_channel.sv
+++ b/fpga/rtl/capture_channel.sv
@@ -22,16 +22,25 @@ module capture_channel #(
 
     logic [DATA_WIDTH-1:0] sample_memory [0:DEPTH-1];
 
-    // Evidence: this is the conventional portable shape for inferred
-    // simple-dual-port RAM: one clocked writer and one clocked reader.
-    // Hypothesis: the Gowin toolchain will map this array into the desired
-    // on-chip memory resource; synthesis reports and hardware remain untested.
+    // Keep RAM writes out of the asynchronous-reset process below. With the
+    // write and registered read in their own clocked processes, Yosys 0.66
+    // preserves this as a dual-port memory and synth_gowin maps the default
+    // 1024 x 8 channels to DPX9B BSRAM primitives. The separate clocks still
+    // do not establish the unrecovered CDC protocol or stock read ordering.
+    always_ff @(posedge read_clk) begin
+        read_data <= sample_memory[read_addr];
+    end
+
+    always_ff @(posedge write_clk) begin
+        if (capture_enable && !freeze) begin
+            sample_memory[write_ptr] <= sample_data;
+        end
+    end
+
     always_ff @(posedge write_clk or negedge reset_n) begin
         if (!reset_n) begin
             write_ptr <= '0;
         end else if (capture_enable && !freeze) begin
-            sample_memory[write_ptr] <= sample_data;
-
             // An explicit terminal comparison supports non-power-of-two DEPTH.
             if (write_ptr == ADDR_WIDTH'(DEPTH - 1)) begin
                 write_ptr <= '0;
@@ -44,8 +53,5 @@ module capture_channel #(
     // The read address is physical. After freezing, write_ptr identifies the
     // oldest entry once the buffer has wrapped; ordering policy belongs above
     // this primitive rather than being hidden in the storage block.
-    always_ff @(posedge read_clk) begin
-        read_data <= sample_memory[read_addr];
-    end
 
 endmodule

--- a/fpga/rtl/capture_channel.sv
+++ b/fpga/rtl/capture_channel.sv
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+module capture_channel #(
+    parameter int unsigned DATA_WIDTH = 8,
+    parameter int unsigned DEPTH = 1024,
+    parameter int unsigned ADDR_WIDTH = (DEPTH <= 1) ? 1 : $clog2(DEPTH)
+) (
+    input  logic                  write_clk,
+    input  logic                  reset_n,
+    input  logic                  capture_enable,
+    input  logic                  freeze,
+    input  logic [DATA_WIDTH-1:0] sample_data,
+
+    input  logic                  read_clk,
+    input  logic [ADDR_WIDTH-1:0] read_addr,
+    output logic [DATA_WIDTH-1:0] read_data,
+
+    output logic [ADDR_WIDTH-1:0] write_ptr
+);
+
+    logic [DATA_WIDTH-1:0] sample_memory [0:DEPTH-1];
+
+    // Evidence: this is the conventional portable shape for inferred
+    // simple-dual-port RAM: one clocked writer and one clocked reader.
+    // Hypothesis: the Gowin toolchain will map this array into the desired
+    // on-chip memory resource; synthesis reports and hardware remain untested.
+    always_ff @(posedge write_clk or negedge reset_n) begin
+        if (!reset_n) begin
+            write_ptr <= '0;
+        end else if (capture_enable && !freeze) begin
+            sample_memory[write_ptr] <= sample_data;
+
+            // An explicit terminal comparison supports non-power-of-two DEPTH.
+            if (write_ptr == ADDR_WIDTH'(DEPTH - 1)) begin
+                write_ptr <= '0;
+            end else begin
+                write_ptr <= write_ptr + 1'b1;
+            end
+        end
+    end
+
+    // The read address is physical. After freezing, write_ptr identifies the
+    // oldest entry once the buffer has wrapped; ordering policy belongs above
+    // this primitive rather than being hidden in the storage block.
+    always_ff @(posedge read_clk) begin
+        read_data <= sample_memory[read_addr];
+    end
+
+endmodule

--- a/fpga/rtl/debugclk_hw_top.sv
+++ b/fpga/rtl/debugclk_hw_top.sv
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+// Hardware validation wrapper: the first buildable image for the real
+// GW1N-UV2/QN48 part, using only the six pins whose apicula IOB locations are
+// netlist-traced and whose QN48 numbers come from the audited UG171 package
+// table (apicula agent/gw1n2-qn48-chipdb-20260815).
+//
+//   pin 30  IOB7B / GCLKC_4  dbg_clk     MCU-driven debug sample clock (PC6)
+//   pin 46  IOR1B            run_enable  master run/arm line (PB11)
+//   pin 34  IOB18A           spi_cs_n
+//   pin 29  IOB5A            spi_sclk
+//   pin 35  IOB18B           spi_mosi
+//   pin 28  IOB5B            spi_so      the design's only IOBUF, as in stock
+//
+// The stock rPLL configuration is still undecoded, so this wrapper substitutes
+// an MCU-paced debug clock on the clock-capable pin instead of claiming a PLL.
+// The ADC pins are similarly unmapped, so the capture path samples synthetic
+// on-chip data: CH1 a free-running ramp, CH2 a walking-one marker -- the R1
+// validator pattern, produced through the real capture write path rather than
+// memory initialization.  The three status positions return the fixed marker
+// bytes "R1V" (0x52 0x31 0x56), deliberately distinguishable from any stock
+// status semantics, which remain unknown.
+//
+// SRAM-only: nothing in this file or its build products authorizes writing the
+// FPGA's non-volatile flash.
+module debugclk_hw_top (
+    input  logic dbg_clk,
+    input  logic run_enable,
+    input  logic spi_cs_n,
+    input  logic spi_sclk,
+    input  logic spi_mosi,
+    inout  wire  spi_so
+);
+
+    localparam logic [7:0] STATUS_MARKER_0 = 8'h52;
+    localparam logic [7:0] STATUS_MARKER_1 = 8'h31;
+    localparam logic [7:0] STATUS_MARKER_2 = 8'h56;
+
+    // Registers power up to zero after configuration, so this shifter holds
+    // the core in reset for the first eight debug-clock edges the MCU sends.
+    // The declaration initializer keeps simulation identical to the Gowin
+    // power-up state; Yosys carries it as the flip-flop INIT value.  Both
+    // waived lints flag exactly what a configuration-time power-on-reset
+    // generator is: an init-value flop chain feeding asynchronous resets.
+    /* verilator lint_off PROCASSINIT */
+    /* verilator lint_off SYNCASYNCNET */
+    logic [7:0] por_shift = '0;
+    logic       reset_n;
+
+    always_ff @(posedge dbg_clk) begin
+        por_shift <= {por_shift[6:0], 1'b1};
+    end
+    assign reset_n = por_shift[7];
+    /* verilator lint_on SYNCASYNCNET */
+    /* verilator lint_on PROCASSINIT */
+
+    // Synthetic ADC sources, free-running like a real converter.
+    logic [7:0] ramp_counter;
+
+    always_ff @(posedge dbg_clk) begin
+        if (!reset_n) begin
+            ramp_counter <= '0;
+        end else begin
+            ramp_counter <= ramp_counter + 1'b1;
+        end
+    end
+
+    logic       spi_miso;
+    logic       spi_miso_oe;
+
+    assign spi_so = spi_miso_oe ? spi_miso : 1'bz;
+
+    // Only the six physical nets exist at this level; the reconstruction
+    // top's observability outputs are simulation aids with no evidenced board
+    // nets, so they are left deliberately unconnected here.
+    /* verilator lint_off PINCONNECTEMPTY */
+    fnirsi_2c53t_top core (
+        .sample_clk(dbg_clk),
+        .reset_n(reset_n),
+        .adc_ch1_data(ramp_counter),
+        .adc_ch2_data(8'h01 << ramp_counter[2:0]),
+        .raw_arm_enable(run_enable),
+        .raw_interval_minus_one('0),
+        .raw_response_status0(STATUS_MARKER_0),
+        .raw_response_status1(STATUS_MARKER_1),
+        .raw_response_status2(STATUS_MARKER_2),
+        .spi_cs_n(spi_cs_n),
+        .spi_sclk(spi_sclk),
+        .spi_mosi(spi_mosi),
+        .spi_miso(spi_miso),
+        .spi_miso_oe(spi_miso_oe),
+        .sample_tick(),
+        .trigger_pulse(),
+        .trigger_seen(),
+        .ch1_at_or_above_level(),
+        .reg_raw_01(),
+        .reg_raw_02(),
+        .reg_raw_06(),
+        .reg_raw_07(),
+        .reg_trigger_level(),
+        .reg_raw_rate_divisor(),
+        .slow_path_tick(),
+        .ch1_write_ptr(),
+        .ch2_write_ptr(),
+        .spi_opcode(),
+        .spi_opcode_valid(),
+        .spi_known_read_active(),
+        .spi_last_opcode(),
+        .spi_last_opcode_known(),
+        .spi_last_byte_count(),
+        .spi_last_known_frame_valid(),
+        .spi_last_known_frame_error(),
+        .spi_unknown_byte_valid(),
+        .spi_rx_byte_valid(),
+        .spi_rx_byte(),
+        .spi_rx_byte_index(),
+        .spi_transaction_byte_count()
+    );
+    /* verilator lint_on PINCONNECTEMPTY */
+
+endmodule

--- a/fpga/rtl/fnirsi_2c53t_top.sv
+++ b/fpga/rtl/fnirsi_2c53t_top.sv
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+module fnirsi_2c53t_top #(
+    parameter int unsigned DATA_WIDTH = 8,
+    parameter int unsigned CAPTURE_DEPTH = 1024,
+    parameter int unsigned CAPTURE_ADDR_WIDTH = (CAPTURE_DEPTH <= 1) ? 1 : $clog2(CAPTURE_DEPTH),
+    parameter int unsigned FRAME_BYTES = 1026,
+    parameter int unsigned SPI_COUNT_WIDTH = 16,
+    parameter int unsigned TIMEBASE_WIDTH = 16
+) (
+    input  logic                              sample_clk,
+    input  logic                              reset_n,
+
+    input  logic [DATA_WIDTH-1:0]             adc_ch1_data,
+    input  logic [DATA_WIDTH-1:0]             adc_ch2_data,
+
+    // Raw local controls.  The stock register map, arming lifecycle,
+    // trigger source/polarity, and timebase encoding are still unknown.
+    input  logic                              raw_arm_enable,
+    input  logic [TIMEBASE_WIDTH-1:0]         raw_interval_minus_one,
+    input  logic                              raw_trigger_event,
+
+    // Raw response bytes for the three non-sample positions used by the
+    // observed 1026-byte CS-low runtime reads.  Their meanings are not decoded
+    // here; firmware or a later evidenced block owns that interpretation.
+    input  logic [7:0]                        raw_response_status0,
+    input  logic [7:0]                        raw_response_status1,
+    input  logic [7:0]                        raw_response_status2,
+
+    input  logic                              spi_cs_n,
+    input  logic                              spi_sclk,
+    input  logic                              spi_mosi,
+    output logic                              spi_miso,
+    output logic                              spi_miso_oe,
+
+    output logic                              sample_tick,
+    output logic                              trigger_pulse,
+    output logic                              trigger_seen,
+
+    output logic [CAPTURE_ADDR_WIDTH-1:0]     ch1_write_ptr,
+    output logic [CAPTURE_ADDR_WIDTH-1:0]     ch2_write_ptr,
+
+    output logic [7:0]                        spi_opcode,
+    output logic                              spi_opcode_valid,
+    output logic                              spi_known_read_active,
+    output logic [7:0]                        spi_last_opcode,
+    output logic                              spi_last_opcode_known,
+    output logic [SPI_COUNT_WIDTH-1:0]        spi_last_byte_count,
+    output logic                              spi_last_known_frame_valid,
+    output logic                              spi_last_known_frame_error,
+    output logic                              spi_unknown_byte_valid,
+    output logic                              spi_rx_byte_valid,
+    output logic [7:0]                        spi_rx_byte,
+    output logic [SPI_COUNT_WIDTH-1:0]        spi_rx_byte_index,
+    output logic [SPI_COUNT_WIDTH-1:0]        spi_transaction_byte_count
+);
+
+    logic [SPI_COUNT_WIDTH-1:0]    response_byte_index;
+    logic [1:0]                    response_channel;
+    logic [7:0]                    response_data;
+
+    logic [CAPTURE_ADDR_WIDTH-1:0] read_addr;
+    logic [DATA_WIDTH-1:0]         ch1_read_data;
+    logic [DATA_WIDTH-1:0]         ch2_read_data;
+    logic                          capture_write_enable;
+    logic                          capture_freeze;
+    logic                          sample_response_byte;
+
+    assign capture_write_enable = raw_arm_enable && sample_tick;
+    assign capture_freeze = trigger_seen;
+    assign sample_response_byte = (response_byte_index >= SPI_COUNT_WIDTH'(3)) &&
+                                  (response_byte_index < SPI_COUNT_WIDTH'(FRAME_BYTES));
+
+    // Assumption boundary: this address feeds the RAM read port clocked by
+    // spi_sclk while the writer is clocked by sample_clk.  That isolates the
+    // current editable model to a dual-port-memory crossing; it is not a claim
+    // that the stock bitstream used this CDC shape or that timing is closed.
+    always_comb begin
+        if (sample_response_byte) begin
+            read_addr = CAPTURE_ADDR_WIDTH'(response_byte_index - SPI_COUNT_WIDTH'(3));
+        end else begin
+            read_addr = '0;
+        end
+    end
+
+    always_comb begin
+        case (response_byte_index)
+            SPI_COUNT_WIDTH'(1): begin
+                response_data = (response_channel != 2'd0) ? raw_response_status1 : 8'h00;
+            end
+            SPI_COUNT_WIDTH'(2): begin
+                response_data = (response_channel != 2'd0) ? raw_response_status2 : 8'h00;
+            end
+            default: begin
+                if (sample_response_byte && response_channel == 2'd1) begin
+                    response_data = ch1_read_data;
+                end else if (sample_response_byte && response_channel == 2'd2) begin
+                    response_data = ch2_read_data;
+                end else begin
+                    response_data = 8'h00;
+                end
+            end
+        endcase
+    end
+
+    trigger_timebase #(
+        .COUNTER_WIDTH(TIMEBASE_WIDTH)
+    ) timebase (
+        .clk(sample_clk),
+        .reset_n(reset_n),
+        .raw_arm_enable(raw_arm_enable),
+        .raw_interval_minus_one(raw_interval_minus_one),
+        .raw_trigger_event(raw_trigger_event),
+        .sample_tick(sample_tick),
+        .trigger_pulse(trigger_pulse),
+        .trigger_seen(trigger_seen)
+    );
+
+    capture_channel #(
+        .DATA_WIDTH(DATA_WIDTH),
+        .DEPTH(CAPTURE_DEPTH),
+        .ADDR_WIDTH(CAPTURE_ADDR_WIDTH)
+    ) ch1_capture (
+        .write_clk(sample_clk),
+        .reset_n(reset_n),
+        .capture_enable(capture_write_enable),
+        .freeze(capture_freeze),
+        .sample_data(adc_ch1_data),
+        .read_clk(spi_sclk),
+        .read_addr(read_addr),
+        .read_data(ch1_read_data),
+        .write_ptr(ch1_write_ptr)
+    );
+
+    capture_channel #(
+        .DATA_WIDTH(DATA_WIDTH),
+        .DEPTH(CAPTURE_DEPTH),
+        .ADDR_WIDTH(CAPTURE_ADDR_WIDTH)
+    ) ch2_capture (
+        .write_clk(sample_clk),
+        .reset_n(reset_n),
+        .capture_enable(capture_write_enable),
+        .freeze(capture_freeze),
+        .sample_data(adc_ch2_data),
+        .read_clk(spi_sclk),
+        .read_addr(read_addr),
+        .read_data(ch2_read_data),
+        .write_ptr(ch2_write_ptr)
+    );
+
+    spi_runtime_interface #(
+        .FRAME_BYTES(FRAME_BYTES),
+        .COUNT_WIDTH(SPI_COUNT_WIDTH)
+    ) spi_runtime (
+        .reset_n(reset_n),
+        .spi_cs_n(spi_cs_n),
+        .spi_sclk(spi_sclk),
+        .spi_mosi(spi_mosi),
+        .spi_miso(spi_miso),
+        .spi_miso_oe(spi_miso_oe),
+        .first_response_byte(raw_response_status0),
+        .response_data(response_data),
+        .response_byte_index(response_byte_index),
+        .response_channel(response_channel),
+        .rx_byte_valid(spi_rx_byte_valid),
+        .rx_byte(spi_rx_byte),
+        .rx_byte_index(spi_rx_byte_index),
+        .unknown_byte_valid(spi_unknown_byte_valid),
+        .opcode(spi_opcode),
+        .opcode_valid(spi_opcode_valid),
+        .known_read_active(spi_known_read_active),
+        .transaction_byte_count(spi_transaction_byte_count),
+        .last_opcode(spi_last_opcode),
+        .last_opcode_known(spi_last_opcode_known),
+        .last_byte_count(spi_last_byte_count),
+        .last_known_frame_valid(spi_last_known_frame_valid),
+        .last_known_frame_error(spi_last_known_frame_error)
+    );
+
+endmodule

--- a/fpga/rtl/fnirsi_2c53t_top.sv
+++ b/fpga/rtl/fnirsi_2c53t_top.sv
@@ -8,7 +8,10 @@ module fnirsi_2c53t_top #(
     parameter int unsigned CAPTURE_ADDR_WIDTH = (CAPTURE_DEPTH <= 1) ? 1 : $clog2(CAPTURE_DEPTH),
     parameter int unsigned FRAME_BYTES = 1026,
     parameter int unsigned SPI_COUNT_WIDTH = 16,
-    parameter int unsigned TIMEBASE_WIDTH = 16
+    parameter int unsigned TIMEBASE_WIDTH = 16,
+    parameter int unsigned SLOW_PATH_DIVISOR_WIDTH = 16,
+    parameter int unsigned SLOW_PATH_BASE_DIVISOR = 16'd1999,
+    parameter int unsigned SLOW_PATH_LEGACY_DIVISOR = 16'd8
 ) (
     input  logic                              sample_clk,
     input  logic                              reset_n,
@@ -41,9 +44,11 @@ module fnirsi_2c53t_top #(
     output logic                              trigger_seen,
     output logic                              ch1_at_or_above_level,
 
-    // Committed SPI control registers.  Only 0x08 has decoded semantics; the
-    // other stock-written registers are re-exposed raw for integration or a
-    // later evidenced block.
+    // Committed SPI control registers.  Register 0x08 is the bench-proven
+    // trigger level; register 0x01 is now also consumed locally as the raw
+    // slow-path rate select byte per the PR #24 / 2026-08-15 reconstruction.
+    // The other stock-written registers remain raw exports for a later
+    // evidenced owner.
     output logic [7:0]                        reg_raw_01,
     output logic [7:0]                        reg_raw_02,
     output logic [7:0]                        reg_raw_06,
@@ -54,7 +59,9 @@ module fnirsi_2c53t_top #(
     // Reconstruction slot for the gated BSRAM_1/2 write cadence: the divided
     // tick is exported instead of instantiating the slow store pair because
     // that record's function (decimation, min/max, roll) is still a
-    // hypothesis.
+    // hypothesis.  The port name keeps historical compatibility even though
+    // the source byte is now raw register 0x01, not a separate placeholder
+    // divisor register.
     output logic                              slow_path_tick,
 
     output logic [CAPTURE_ADDR_WIDTH-1:0]     ch1_write_ptr,
@@ -163,12 +170,15 @@ module fnirsi_2c53t_top #(
     );
 
     rate_divider #(
-        .DIVISOR_WIDTH(8)
+        .SELECT_WIDTH(8),
+        .DIVISOR_WIDTH(SLOW_PATH_DIVISOR_WIDTH),
+        .BASE_DIVISOR(SLOW_PATH_BASE_DIVISOR),
+        .LEGACY_SLOW_DEFAULT_DIVISOR(SLOW_PATH_LEGACY_DIVISOR)
     ) slow_path_rate (
         .clk(sample_clk),
         .reset_n(reset_n),
         .enable(raw_arm_enable),
-        .raw_divisor(reg_raw_rate_divisor),
+        .raw_divisor(reg_raw_01),
         .divided_tick(slow_path_tick)
     );
 

--- a/fpga/rtl/fnirsi_2c53t_top.sv
+++ b/fpga/rtl/fnirsi_2c53t_top.sv
@@ -16,11 +16,12 @@ module fnirsi_2c53t_top #(
     input  logic [DATA_WIDTH-1:0]             adc_ch1_data,
     input  logic [DATA_WIDTH-1:0]             adc_ch2_data,
 
-    // Raw local controls.  The stock register map, arming lifecycle,
-    // trigger source/polarity, and timebase encoding are still unknown.
+    // Raw local controls.  The complete stock register map, arming lifecycle,
+    // and timebase encoding are still unknown; the trigger event is no longer
+    // an input because the comparator is bench-evidenced as digital and
+    // post-ADC, driven by SPI register 0x08 (see trigger_comparator).
     input  logic                              raw_arm_enable,
     input  logic [TIMEBASE_WIDTH-1:0]         raw_interval_minus_one,
-    input  logic                              raw_trigger_event,
 
     // Raw response bytes for the three non-sample positions used by the
     // observed 1026-byte CS-low runtime reads.  Their meanings are not decoded
@@ -38,6 +39,23 @@ module fnirsi_2c53t_top #(
     output logic                              sample_tick,
     output logic                              trigger_pulse,
     output logic                              trigger_seen,
+    output logic                              ch1_at_or_above_level,
+
+    // Committed SPI control registers.  Only 0x08 has decoded semantics; the
+    // other stock-written registers are re-exposed raw for integration or a
+    // later evidenced block.
+    output logic [7:0]                        reg_raw_01,
+    output logic [7:0]                        reg_raw_02,
+    output logic [7:0]                        reg_raw_06,
+    output logic [7:0]                        reg_raw_07,
+    output logic [7:0]                        reg_trigger_level,
+    output logic [7:0]                        reg_raw_rate_divisor,
+
+    // Reconstruction slot for the gated BSRAM_1/2 write cadence: the divided
+    // tick is exported instead of instantiating the slow store pair because
+    // that record's function (decimation, min/max, roll) is still a
+    // hypothesis.
+    output logic                              slow_path_tick,
 
     output logic [CAPTURE_ADDR_WIDTH-1:0]     ch1_write_ptr,
     output logic [CAPTURE_ADDR_WIDTH-1:0]     ch2_write_ptr,
@@ -67,6 +85,7 @@ module fnirsi_2c53t_top #(
     logic                          capture_write_enable;
     logic                          capture_freeze;
     logic                          sample_response_byte;
+    logic                          ch1_crossing_event;
 
     assign capture_write_enable = raw_arm_enable && sample_tick;
     assign capture_freeze = trigger_seen;
@@ -105,6 +124,54 @@ module fnirsi_2c53t_top #(
         endcase
     end
 
+    // Commit boundary is CS rising, matching the observed stock write frames.
+    // The committed values cross into the sample_clk domain without a
+    // recovered CDC protocol, the same declared limitation as the capture
+    // memories' dual-clock read path.
+    spi_control_registers #(
+        .COUNT_WIDTH(SPI_COUNT_WIDTH)
+    ) control_registers (
+        .reset_n(reset_n),
+        .spi_cs_n(spi_cs_n),
+        .opcode_select(spi_opcode[4:0]),
+        .opcode_valid(spi_opcode_valid),
+        .known_read_active(spi_known_read_active),
+        .transaction_byte_count(spi_transaction_byte_count),
+        .rx_byte(spi_rx_byte),
+        .raw_reg_01(reg_raw_01),
+        .raw_reg_02(reg_raw_02),
+        .raw_reg_06(reg_raw_06),
+        .raw_reg_07(reg_raw_07),
+        .trigger_level(reg_trigger_level),
+        .raw_rate_divisor(reg_raw_rate_divisor)
+    );
+
+    // CH1 is the trigger source here because every bench trigger observation
+    // is CH1-side and the b2 freshness flag appears on CH1 reads only; stock
+    // source and edge selection remain unknown.
+    trigger_comparator #(
+        .DATA_WIDTH(DATA_WIDTH)
+    ) ch1_trigger (
+        .clk(sample_clk),
+        .reset_n(reset_n),
+        .arm_enable(raw_arm_enable),
+        .sample_valid(sample_tick),
+        .sample_data(adc_ch1_data),
+        .trigger_level(reg_trigger_level),
+        .at_or_above_level(ch1_at_or_above_level),
+        .crossing_event(ch1_crossing_event)
+    );
+
+    rate_divider #(
+        .DIVISOR_WIDTH(8)
+    ) slow_path_rate (
+        .clk(sample_clk),
+        .reset_n(reset_n),
+        .enable(raw_arm_enable),
+        .raw_divisor(reg_raw_rate_divisor),
+        .divided_tick(slow_path_tick)
+    );
+
     trigger_timebase #(
         .COUNTER_WIDTH(TIMEBASE_WIDTH)
     ) timebase (
@@ -112,7 +179,7 @@ module fnirsi_2c53t_top #(
         .reset_n(reset_n),
         .raw_arm_enable(raw_arm_enable),
         .raw_interval_minus_one(raw_interval_minus_one),
-        .raw_trigger_event(raw_trigger_event),
+        .raw_trigger_event(ch1_crossing_event),
         .sample_tick(sample_tick),
         .trigger_pulse(trigger_pulse),
         .trigger_seen(trigger_seen)

--- a/fpga/rtl/rate_divider.sv
+++ b/fpga/rtl/rate_divider.sv
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+module rate_divider #(
+    parameter int unsigned DIVISOR_WIDTH = 8
+) (
+    input  logic                     clk,
+    input  logic                     reset_n,
+    input  logic                     enable,
+
+    // Raw byte-shaped divisor with the same local contract as the timebase
+    // interval: one divided_tick every (raw_divisor + 1) enabled clock cycles.
+    input  logic [DIVISOR_WIDTH-1:0] raw_divisor,
+
+    output logic                     divided_tick
+);
+
+    logic [DIVISOR_WIDTH-1:0] phase_counter;
+
+    // Structural target (gw1n2-apicula M12): BSRAM_1/2 write on a gated
+    // fabric clock whose gate cone is a self-feeding counter with an SPI-side
+    // load path -- the structural definition of a programmable sample-rate
+    // divider, not a bare enable.  This block reconstructs that shape on the
+    // editable side: counter state feeding a periodic gate.  The stock divisor
+    // value, its register address, and the mapping between the measured slow
+    // default rate and stock's ~23x faster regime all remain unproven, so
+    // this counter claims only the declared local behavior.
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            phase_counter <= '0;
+            divided_tick  <= 1'b0;
+        end else if (!enable) begin
+            phase_counter <= '0;
+            divided_tick  <= 1'b0;
+        end else begin
+            divided_tick <= 1'b0;
+            if (phase_counter == raw_divisor) begin
+                phase_counter <= '0;
+                divided_tick  <= 1'b1;
+            end else begin
+                phase_counter <= phase_counter + 1'b1;
+            end
+        end
+    end
+
+endmodule

--- a/fpga/rtl/rate_divider.sv
+++ b/fpga/rtl/rate_divider.sv
@@ -3,29 +3,90 @@
 `timescale 1ns/1ps
 
 module rate_divider #(
-    parameter int unsigned DIVISOR_WIDTH = 8
+    parameter int unsigned SELECT_WIDTH = 8,
+    parameter int unsigned DIVISOR_WIDTH = 16,
+    parameter int unsigned BASE_DIVISOR = 16'd1999,
+    parameter int unsigned LEGACY_SLOW_DEFAULT_DIVISOR = 16'd8
 ) (
     input  logic                     clk,
     input  logic                     reset_n,
     input  logic                     enable,
 
-    // Raw byte-shaped divisor with the same local contract as the timebase
-    // interval: one divided_tick every (raw_divisor + 1) enabled clock cycles.
-    input  logic [DIVISOR_WIDTH-1:0] raw_divisor,
+    // Raw register 0x01 byte.  The 2026-08-15 bench sweep (upstream PR #24)
+    // identified its low nibble as a 1-2-5 sample-rate ladder, measured as
+    // 0x0F ~30 kS/s, 0x0E ~60k, 0x0D ~150k, 0x0C ~300k, 0x0B ~500-600k,
+    // 0x0A ~1 MS/s, with 0x10/0x1F one further slow step at ~15 kS/s.  The
+    // decode below scales the DIVISOR (the interval), so 0x0F carries the
+    // largest ladder divisor and each faster step divides it (/2, /5, /10,
+    // /20, /33) while 0x10/0x1F doubles it.  The absolute base clock is
+    // unknown: BASE_DIVISOR is a parameter and only the measured ratios are
+    // claimed.  0x08 (the stock arm default) is not on the ladder -- bench
+    // shows tone-independent zero-crossing counts, i.e. not a uniform sample
+    // rate -- so it keeps the old local slow-default divider as a distinct
+    // unproven mode.
+    input  logic [SELECT_WIDTH-1:0] raw_divisor,
 
     output logic                     divided_tick
 );
 
     logic [DIVISOR_WIDTH-1:0] phase_counter;
+    logic [DIVISOR_WIDTH-1:0] effective_divisor;
+
+    localparam logic [SELECT_WIDTH-1:0] RATE_SEL_SLOW_DEFAULT = 8'h08;
+    localparam logic [SELECT_WIDTH-1:0] RATE_SEL_BASE         = 8'h0f;
+    localparam logic [SELECT_WIDTH-1:0] RATE_SEL_BASE_DIV2    = 8'h0e;
+    localparam logic [SELECT_WIDTH-1:0] RATE_SEL_BASE_DIV5    = 8'h0d;
+    localparam logic [SELECT_WIDTH-1:0] RATE_SEL_BASE_DIV10   = 8'h0c;
+    localparam logic [SELECT_WIDTH-1:0] RATE_SEL_BASE_DIV20   = 8'h0b;
+    localparam logic [SELECT_WIDTH-1:0] RATE_SEL_BASE_DIV33   = 8'h0a;
+    localparam logic [SELECT_WIDTH-1:0] RATE_SEL_15K_A        = 8'h10;
+    localparam logic [SELECT_WIDTH-1:0] RATE_SEL_15K_B        = 8'h1f;
+
+    always_comb begin
+        effective_divisor = DIVISOR_WIDTH'(LEGACY_SLOW_DEFAULT_DIVISOR);
+        unique case (raw_divisor)
+            RATE_SEL_BASE: begin
+                effective_divisor = DIVISOR_WIDTH'(BASE_DIVISOR);
+            end
+            RATE_SEL_BASE_DIV2: begin
+                effective_divisor = DIVISOR_WIDTH'(BASE_DIVISOR / 2);
+            end
+            RATE_SEL_BASE_DIV5: begin
+                effective_divisor = DIVISOR_WIDTH'(BASE_DIVISOR / 5);
+            end
+            RATE_SEL_BASE_DIV10: begin
+                effective_divisor = DIVISOR_WIDTH'(BASE_DIVISOR / 10);
+            end
+            RATE_SEL_BASE_DIV20: begin
+                effective_divisor = DIVISOR_WIDTH'(BASE_DIVISOR / 20);
+            end
+            RATE_SEL_BASE_DIV33: begin
+                // Integer approximation of the measured ~1 MS/s point:
+                // the interval is about 33.3x faster than the 0F interval.
+                effective_divisor = DIVISOR_WIDTH'(BASE_DIVISOR / 33);
+            end
+            RATE_SEL_15K_A,
+            RATE_SEL_15K_B: begin
+                // 15 kS/s is one further slow step: twice the 0F interval.
+                effective_divisor = DIVISOR_WIDTH'(BASE_DIVISOR * 2);
+            end
+            RATE_SEL_SLOW_DEFAULT: begin
+                effective_divisor = DIVISOR_WIDTH'(LEGACY_SLOW_DEFAULT_DIVISOR);
+            end
+            default: begin
+                effective_divisor = DIVISOR_WIDTH'(LEGACY_SLOW_DEFAULT_DIVISOR);
+            end
+        endcase
+    end
 
     // Structural target (gw1n2-apicula M12): BSRAM_1/2 write on a gated
     // fabric clock whose gate cone is a self-feeding counter with an SPI-side
     // load path -- the structural definition of a programmable sample-rate
     // divider, not a bare enable.  This block reconstructs that shape on the
-    // editable side: counter state feeding a periodic gate.  The stock divisor
-    // value, its register address, and the mapping between the measured slow
-    // default rate and stock's ~23x faster regime all remain unproven, so
-    // this counter claims only the declared local behavior.
+    // editable side: counter state feeding a periodic gate.  The exact stock
+    // clock, divider preload convention, and semantics of 0x08 versus the
+    // ladder modes are still not fully bench-closed, so this block claims only
+    // the declared local decode and interval contract.
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n) begin
             phase_counter <= '0;
@@ -35,7 +96,7 @@ module rate_divider #(
             divided_tick  <= 1'b0;
         end else begin
             divided_tick <= 1'b0;
-            if (phase_counter == raw_divisor) begin
+            if (phase_counter == effective_divisor) begin
                 phase_counter <= '0;
                 divided_tick  <= 1'b1;
             end else begin

--- a/fpga/rtl/spi_control_registers.sv
+++ b/fpga/rtl/spi_control_registers.sv
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+module spi_control_registers #(
+    parameter int unsigned COUNT_WIDTH = 16,
+    // PLACEHOLDER SELECT, NOT EVIDENCE: netlist tracing (gw1n2-apicula M12)
+    // shows the gated BSRAM_1/2 write clock behind a counter whose load path
+    // reaches the SPI receiver bank, but the divisor register address has not
+    // been identified.  The byte-exact stock arm replay (2026-08-14) stayed at
+    // the slow default rate, which argues the five observed arm registers are
+    // not that divisor, so the placeholder deliberately sits outside them at
+    // an unobserved address.  Replace it the moment the bench or netlist pins
+    // the real select.
+    parameter logic [4:0] RAW_RATE_DIVISOR_SELECT = 5'h0b
+) (
+    input  logic                   reset_n,
+    input  logic                   spi_cs_n,
+
+    // The select port is deliberately five bits wide: applying the read
+    // path's bench-proven low-five-bit decode to write selects is this
+    // block's declared hypothesis.
+    input  logic [4:0]             opcode_select,
+    input  logic                   opcode_valid,
+    input  logic                   known_read_active,
+    input  logic [COUNT_WIDTH-1:0] transaction_byte_count,
+    input  logic [7:0]             rx_byte,
+
+    output logic [7:0]             raw_reg_01,
+    output logic [7:0]             raw_reg_02,
+    output logic [7:0]             raw_reg_06,
+    output logic [7:0]             raw_reg_07,
+    output logic [7:0]             trigger_level,
+    output logic [7:0]             raw_rate_divisor
+);
+
+    // Reset defaults are the stock arm-sequence values (01 08 / 02 03 / 06 00
+    // / 07 00 / 08 AD) so an unwritten reconstruction matches the only fully
+    // observed register state.  The true pre-write power-on contents are
+    // unknown; only register 0x08 has decoded semantics (the digital post-ADC
+    // trigger level, bench-proven 2026-08-14).  Registers 0x01/0x02/0x06/0x07
+    // are stored and re-exposed raw.
+    localparam logic [7:0] RESET_REG_01        = 8'h08;
+    localparam logic [7:0] RESET_REG_02        = 8'h03;
+    localparam logic [7:0] RESET_REG_06        = 8'h00;
+    localparam logic [7:0] RESET_REG_07        = 8'h00;
+    localparam logic [7:0] RESET_TRIGGER_LEVEL = 8'had;
+    localparam logic [7:0] RESET_RATE_DIVISOR  = 8'h00;
+
+    // Every observed stock write is a two-byte CS-low frame: a select byte
+    // followed by one value byte.  Commit therefore happens at the observed
+    // transaction boundary (CS rising), only for exactly-two-byte frames whose
+    // first byte is not a known channel read.  Longer or shorter unknown
+    // frames stay raw events upstream.
+    always_ff @(posedge spi_cs_n or negedge reset_n) begin
+        if (!reset_n) begin
+            raw_reg_01       <= RESET_REG_01;
+            raw_reg_02       <= RESET_REG_02;
+            raw_reg_06       <= RESET_REG_06;
+            raw_reg_07       <= RESET_REG_07;
+            trigger_level    <= RESET_TRIGGER_LEVEL;
+            raw_rate_divisor <= RESET_RATE_DIVISOR;
+        end else if (opcode_valid && !known_read_active &&
+                     (transaction_byte_count == COUNT_WIDTH'(2))) begin
+            case (opcode_select)
+                5'h01:   raw_reg_01    <= rx_byte;
+                5'h02:   raw_reg_02    <= rx_byte;
+                5'h06:   raw_reg_06    <= rx_byte;
+                5'h07:   raw_reg_07    <= rx_byte;
+                5'h08:   trigger_level <= rx_byte;
+                default: begin
+                    if (opcode_select == RAW_RATE_DIVISOR_SELECT) begin
+                        raw_rate_divisor <= rx_byte;
+                    end
+                end
+            endcase
+        end
+    end
+
+endmodule

--- a/fpga/rtl/spi_control_registers.sv
+++ b/fpga/rtl/spi_control_registers.sv
@@ -3,16 +3,7 @@
 `timescale 1ns/1ps
 
 module spi_control_registers #(
-    parameter int unsigned COUNT_WIDTH = 16,
-    // PLACEHOLDER SELECT, NOT EVIDENCE: netlist tracing (gw1n2-apicula M12)
-    // shows the gated BSRAM_1/2 write clock behind a counter whose load path
-    // reaches the SPI receiver bank, but the divisor register address has not
-    // been identified.  The byte-exact stock arm replay (2026-08-14) stayed at
-    // the slow default rate, which argues the five observed arm registers are
-    // not that divisor, so the placeholder deliberately sits outside them at
-    // an unobserved address.  Replace it the moment the bench or netlist pins
-    // the real select.
-    parameter logic [4:0] RAW_RATE_DIVISOR_SELECT = 5'h0b
+    parameter int unsigned COUNT_WIDTH = 16
 ) (
     input  logic                   reset_n,
     input  logic                   spi_cs_n,
@@ -37,15 +28,21 @@ module spi_control_registers #(
     // Reset defaults are the stock arm-sequence values (01 08 / 02 03 / 06 00
     // / 07 00 / 08 AD) so an unwritten reconstruction matches the only fully
     // observed register state.  The true pre-write power-on contents are
-    // unknown; only register 0x08 has decoded semantics (the digital post-ADC
-    // trigger level, bench-proven 2026-08-14).  Registers 0x01/0x02/0x06/0x07
-    // are stored and re-exposed raw.
+    // unknown; register 0x08 is the digital post-ADC trigger level (bench
+    // proven 2026-08-14), and register 0x01 now selects the measured rate
+    // ladder. Registers 0x01/0x02/0x06/0x07 remain exposed raw.
     localparam logic [7:0] RESET_REG_01        = 8'h08;
     localparam logic [7:0] RESET_REG_02        = 8'h03;
     localparam logic [7:0] RESET_REG_06        = 8'h00;
     localparam logic [7:0] RESET_REG_07        = 8'h00;
     localparam logic [7:0] RESET_TRIGGER_LEVEL = 8'had;
-    localparam logic [7:0] RESET_RATE_DIVISOR  = 8'h00;
+
+    // Compatibility alias only: PR #24 (2026-08-15) moved the slow-path rate
+    // select onto observed register 0x01, so there is no longer a separate
+    // placeholder write path.  Keep exposing the old port name so existing
+    // top-level/sim wiring still sees the raw byte, but the single source of
+    // truth is raw_reg_01.
+    assign raw_rate_divisor = raw_reg_01;
 
     // Every observed stock write is a two-byte CS-low frame: a select byte
     // followed by one value byte.  Commit therefore happens at the observed
@@ -59,7 +56,6 @@ module spi_control_registers #(
             raw_reg_06       <= RESET_REG_06;
             raw_reg_07       <= RESET_REG_07;
             trigger_level    <= RESET_TRIGGER_LEVEL;
-            raw_rate_divisor <= RESET_RATE_DIVISOR;
         end else if (opcode_valid && !known_read_active &&
                      (transaction_byte_count == COUNT_WIDTH'(2))) begin
             case (opcode_select)
@@ -68,11 +64,7 @@ module spi_control_registers #(
                 5'h06:   raw_reg_06    <= rx_byte;
                 5'h07:   raw_reg_07    <= rx_byte;
                 5'h08:   trigger_level <= rx_byte;
-                default: begin
-                    if (opcode_select == RAW_RATE_DIVISOR_SELECT) begin
-                        raw_rate_divisor <= rx_byte;
-                    end
-                end
+                default: ;
             endcase
         end
     end

--- a/fpga/rtl/spi_runtime_interface.sv
+++ b/fpga/rtl/spi_runtime_interface.sv
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+module spi_runtime_interface #(
+    parameter int unsigned FRAME_BYTES = 1026,
+    parameter int unsigned COUNT_WIDTH = 16
+) (
+    input  logic                   reset_n,
+    input  logic                   spi_cs_n,
+    input  logic                   spi_sclk,
+    input  logic                   spi_mosi,
+    output logic                   spi_miso,
+    output logic                   spi_miso_oe,
+
+    // Byte zero is already on MISO when the transaction starts.  For every
+    // later byte, response_byte_index identifies the byte that the caller
+    // must present on response_data before its first bit is shifted out.
+    input  logic [7:0]             first_response_byte,
+    input  logic [7:0]             response_data,
+    output logic [COUNT_WIDTH-1:0] response_byte_index,
+    output logic [1:0]             response_channel,
+
+    // Every received byte is exposed.  Unknown commands deliberately use the
+    // same raw event path; their payload is not decoded or discarded here.
+    output logic                   rx_byte_valid,
+    output logic [7:0]             rx_byte,
+    output logic [COUNT_WIDTH-1:0] rx_byte_index,
+    output logic                   unknown_byte_valid,
+
+    output logic [7:0]             opcode,
+    output logic                   opcode_valid,
+    output logic                   known_read_active,
+    output logic [COUNT_WIDTH-1:0] transaction_byte_count,
+
+    // These values latch when CS rises and remain stable until the next end.
+    output logic [7:0]             last_opcode,
+    output logic                   last_opcode_known,
+    output logic [COUNT_WIDTH-1:0] last_byte_count,
+    output logic                   last_known_frame_valid,
+    output logic                   last_known_frame_error
+);
+
+    localparam logic [7:0] OPCODE_CH1 = 8'h04;
+    localparam logic [7:0] OPCODE_CH2 = 8'h05;
+
+    logic [2:0] rx_bit_index;
+    logic [6:0] rx_shift;
+    logic [2:0] tx_bit_index;
+    logic [7:0] tx_shift;
+    logic       tx_first_byte;
+    logic       tx_first_edge;
+
+    logic [7:0] completed_rx_byte;
+    logic       completed_opcode_known;
+    logic       spi_inactive;
+
+    assign completed_rx_byte = {rx_shift, spi_mosi};
+    assign completed_opcode_known = (completed_rx_byte == OPCODE_CH1) ||
+                                    (completed_rx_byte == OPCODE_CH2);
+    assign spi_inactive = !reset_n || spi_cs_n;
+    assign spi_miso = tx_first_byte ? first_response_byte[7-tx_bit_index] : tx_shift[7];
+    assign spi_miso_oe = !spi_cs_n;
+
+    always_comb begin
+        if (opcode_valid && (opcode == OPCODE_CH1)) begin
+            response_channel = 2'd1;
+        end else if (opcode_valid && (opcode == OPCODE_CH2)) begin
+            response_channel = 2'd2;
+        end else begin
+            response_channel = 2'd0;
+        end
+    end
+
+    // Evidence: the stock MCU uses SPI mode 3, so MOSI is sampled on rising
+    // SCLK edges.  The only interpreted runtime opcodes are the observed CH1
+    // and CH2 reads.  Their status bytes, sample ordering, and every other
+    // command remain outside this block because those semantics are unproven.
+    always_ff @(posedge spi_sclk or posedge spi_inactive) begin
+        if (spi_inactive) begin
+            rx_bit_index             <= '0;
+            rx_shift                 <= '0;
+            rx_byte_valid            <= 1'b0;
+            rx_byte                  <= '0;
+            rx_byte_index            <= '0;
+            unknown_byte_valid       <= 1'b0;
+            opcode                   <= '0;
+            opcode_valid             <= 1'b0;
+            known_read_active        <= 1'b0;
+            transaction_byte_count   <= '0;
+        end else begin
+            rx_byte_valid        <= 1'b0;
+            unknown_byte_valid   <= 1'b0;
+            rx_shift             <= completed_rx_byte[6:0];
+
+            if (rx_bit_index == 3'd7) begin
+                rx_bit_index           <= '0;
+                rx_byte                <= completed_rx_byte;
+                rx_byte_index          <= transaction_byte_count;
+                rx_byte_valid          <= 1'b1;
+                transaction_byte_count <= transaction_byte_count + 1'b1;
+
+                if (!opcode_valid) begin
+                    opcode             <= completed_rx_byte;
+                    opcode_valid       <= 1'b1;
+                    known_read_active  <= completed_opcode_known;
+                    unknown_byte_valid <= !completed_opcode_known;
+                end else begin
+                    unknown_byte_valid <= !known_read_active;
+                end
+            end else begin
+                rx_bit_index <= rx_bit_index + 1'b1;
+            end
+        end
+    end
+
+    // CS rising is the observed transaction boundary.  Keeping completed-frame
+    // metadata in this small CS-clocked bank avoids pretending that another,
+    // currently unknown system clock owns the SPI protocol state.
+    always_ff @(posedge spi_cs_n or negedge reset_n) begin
+        if (!reset_n) begin
+            last_opcode            <= '0;
+            last_opcode_known      <= 1'b0;
+            last_byte_count        <= '0;
+            last_known_frame_valid <= 1'b0;
+            last_known_frame_error <= 1'b0;
+        end else begin
+            last_opcode            <= opcode;
+            last_opcode_known      <= opcode_valid && known_read_active;
+            last_byte_count        <= transaction_byte_count;
+            last_known_frame_valid <= opcode_valid && known_read_active &&
+                                      (transaction_byte_count == COUNT_WIDTH'(FRAME_BYTES));
+            last_known_frame_error <= opcode_valid && known_read_active &&
+                                      (transaction_byte_count != COUNT_WIDTH'(FRAME_BYTES));
+        end
+    end
+
+    // MISO changes on falling SCLK edges and is stable at the rising sampling
+    // edge.  response_data is intentionally a transparent byte source: for
+    // known reads the integration layer may provide status/sample bytes; for
+    // unknown commands it may expose any separately recovered raw behavior.
+    always_ff @(negedge spi_sclk or posedge spi_inactive) begin
+        if (spi_inactive) begin
+            tx_bit_index        <= '0;
+            tx_shift            <= '0;
+            tx_first_byte       <= 1'b1;
+            tx_first_edge       <= 1'b1;
+            response_byte_index <= COUNT_WIDTH'(1);
+        end else if (tx_first_edge) begin
+            // Mode 3 begins with a falling edge.  Byte zero comes directly
+            // from first_response_byte, so this edge must not advance past its
+            // most-significant bit.
+            tx_first_edge <= 1'b0;
+        end else if (tx_bit_index == 3'd7) begin
+            tx_bit_index        <= '0;
+            tx_shift            <= response_data;
+            tx_first_byte       <= 1'b0;
+            response_byte_index <= response_byte_index + 1'b1;
+        end else begin
+            tx_bit_index <= tx_bit_index + 1'b1;
+            tx_shift     <= {tx_shift[6:0], 1'b0};
+        end
+    end
+
+endmodule

--- a/fpga/rtl/spi_runtime_interface.sv
+++ b/fpga/rtl/spi_runtime_interface.sv
@@ -41,8 +41,12 @@ module spi_runtime_interface #(
     output logic                   last_known_frame_error
 );
 
-    localparam logic [7:0] OPCODE_CH1 = 8'h04;
-    localparam logic [7:0] OPCODE_CH2 = 8'h05;
+    // Bench opcode sweep (2026-08-14): opcodes 0x20-0x3F alias 0x00-0x1F
+    // exactly, including live channel data on 0x24/0x25, so the stock design
+    // decodes only the low five opcode bits.  The full received byte is still
+    // exposed raw on the opcode outputs.
+    localparam logic [4:0] OPCODE_SELECT_CH1 = 5'h04;
+    localparam logic [4:0] OPCODE_SELECT_CH2 = 5'h05;
 
     logic [2:0] rx_bit_index;
     logic [6:0] rx_shift;
@@ -54,18 +58,20 @@ module spi_runtime_interface #(
     logic [7:0] completed_rx_byte;
     logic       completed_opcode_known;
     logic       spi_inactive;
+    logic [4:0] opcode_select;
 
     assign completed_rx_byte = {rx_shift, spi_mosi};
-    assign completed_opcode_known = (completed_rx_byte == OPCODE_CH1) ||
-                                    (completed_rx_byte == OPCODE_CH2);
+    assign completed_opcode_known = (completed_rx_byte[4:0] == OPCODE_SELECT_CH1) ||
+                                    (completed_rx_byte[4:0] == OPCODE_SELECT_CH2);
     assign spi_inactive = !reset_n || spi_cs_n;
     assign spi_miso = tx_first_byte ? first_response_byte[7-tx_bit_index] : tx_shift[7];
     assign spi_miso_oe = !spi_cs_n;
+    assign opcode_select = opcode[4:0];
 
     always_comb begin
-        if (opcode_valid && (opcode == OPCODE_CH1)) begin
+        if (opcode_valid && (opcode_select == OPCODE_SELECT_CH1)) begin
             response_channel = 2'd1;
-        end else if (opcode_valid && (opcode == OPCODE_CH2)) begin
+        end else if (opcode_valid && (opcode_select == OPCODE_SELECT_CH2)) begin
             response_channel = 2'd2;
         end else begin
             response_channel = 2'd0;

--- a/fpga/rtl/trigger_comparator.sv
+++ b/fpga/rtl/trigger_comparator.sv
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+module trigger_comparator #(
+    parameter int unsigned DATA_WIDTH = 8
+) (
+    input  logic                  clk,
+    input  logic                  reset_n,
+    input  logic                  arm_enable,
+    input  logic                  sample_valid,
+    input  logic [DATA_WIDTH-1:0] sample_data,
+    input  logic [DATA_WIDTH-1:0] trigger_level,
+
+    output logic                  at_or_above_level,
+    output logic                  crossing_event
+);
+
+    logic level_history_valid;
+
+    // Evidence: SPI register 0x08 is a digital post-ADC trigger level in ADC
+    // codes, bench-proven in both directions (2026-08-14): quiet noise below
+    // stock's armed level 0xAD produces no events, moving the level into the
+    // noise band produces events, and restoring the level stops them.  The
+    // comparator therefore belongs in the fabric, after the ADC, comparing
+    // codes rather than analog voltages.
+    //
+    // Hypothesis boundary: a noise band straddling the level fires on rising
+    // and falling readings alike, so the bench cannot separate edge polarity,
+    // and stock's edge selection, hysteresis, holdoff, and trigger source
+    // encoding remain unrecovered.  This block declares one local contract: a
+    // one-cycle event on a rising crossing of trigger_level, evaluated only on
+    // qualified samples.
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            at_or_above_level   <= 1'b0;
+            level_history_valid <= 1'b0;
+            crossing_event      <= 1'b0;
+        end else if (!arm_enable) begin
+            at_or_above_level   <= 1'b0;
+            level_history_valid <= 1'b0;
+            crossing_event      <= 1'b0;
+        end else begin
+            crossing_event <= 1'b0;
+            if (sample_valid) begin
+                at_or_above_level   <= (sample_data >= trigger_level);
+                level_history_valid <= 1'b1;
+                // The first qualified sample after arming only seeds the
+                // comparison history; a crossing needs a preceding qualified
+                // sample below the level.
+                crossing_event <= level_history_valid && !at_or_above_level &&
+                                  (sample_data >= trigger_level);
+            end
+        end
+    end
+
+endmodule

--- a/fpga/rtl/trigger_timebase.sv
+++ b/fpga/rtl/trigger_timebase.sv
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+module trigger_timebase #(
+    parameter int unsigned COUNTER_WIDTH = 16
+) (
+    input  logic                     clk,
+    input  logic                     reset_n,
+    // Raw active-high local arm gate. Stock source, polarity, and re-arm
+    // sequencing remain unknown.
+    input  logic                     raw_arm_enable,
+
+    // Raw reconstruction control, not a recovered stock register encoding.
+    // This local contract emits one sample_tick every
+    // (raw_interval_minus_one + 1) active clock cycles.
+    input  logic [COUNTER_WIDTH-1:0] raw_interval_minus_one,
+
+    // Raw event from an external comparator/decoder. Threshold, source, edge
+    // polarity, holdoff, and stock command encoding are intentionally outside
+    // this primitive because none of those semantics has been recovered.
+    input  logic                     raw_trigger_event,
+
+    output logic                     sample_tick,
+    output logic                     trigger_pulse,
+    output logic                     trigger_seen
+);
+
+    logic [COUNTER_WIDTH-1:0] interval_counter;
+
+    // Hypothesis boundary: a programmable periodic enable is useful for an
+    // editable timebase, but the stock raw capture memories are evidenced on
+    // an undivided PLL clock and the slower computed path uses an unresolved
+    // gated fabric clock. This counter therefore proves only the declared
+    // local behavior; it is not claimed to match either stock clock path.
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            interval_counter <= '0;
+            sample_tick      <= 1'b0;
+            trigger_pulse    <= 1'b0;
+            trigger_seen     <= 1'b0;
+        end else if (!raw_arm_enable) begin
+            interval_counter <= '0;
+            sample_tick      <= 1'b0;
+            trigger_pulse    <= 1'b0;
+            trigger_seen     <= 1'b0;
+        end else begin
+            sample_tick   <= 1'b0;
+            trigger_pulse <= 1'b0;
+
+            if (interval_counter == raw_interval_minus_one) begin
+                interval_counter <= '0;
+                sample_tick      <= 1'b1;
+            end else begin
+                interval_counter <= interval_counter + 1'b1;
+            end
+
+            // Latch only the first event in an armed interval. What capture
+            // does after this pulse (freeze, post-trigger count, or re-arm) is
+            // deliberately left to an integration layer.
+            if (raw_trigger_event && !trigger_seen) begin
+                trigger_pulse <= 1'b1;
+                trigger_seen  <= 1'b1;
+            end
+        end
+    end
+
+endmodule

--- a/fpga/sim/tb_capture_channel.sv
+++ b/fpga/sim/tb_capture_channel.sv
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+module tb_capture_channel;
+
+    localparam int unsigned DATA_WIDTH = 8;
+    localparam int unsigned DEPTH = 5;
+    localparam int unsigned ADDR_WIDTH = $clog2(DEPTH);
+
+    logic                  write_clk;
+    logic                  read_clk;
+    logic                  reset_n;
+    logic                  capture_enable;
+    logic                  freeze;
+    logic [DATA_WIDTH-1:0] sample_data;
+    logic [ADDR_WIDTH-1:0] read_addr;
+    logic [DATA_WIDTH-1:0] read_data;
+    logic [ADDR_WIDTH-1:0] write_ptr;
+
+    logic [DATA_WIDTH-1:0] expected [0:DEPTH-1];
+    int unsigned failures;
+
+    always #5 write_clk = ~write_clk;
+    always #7 read_clk = ~read_clk;
+
+    capture_channel #(
+        .DATA_WIDTH(DATA_WIDTH),
+        .DEPTH(DEPTH),
+        .ADDR_WIDTH(ADDR_WIDTH)
+    ) dut (
+        .write_clk(write_clk),
+        .reset_n(reset_n),
+        .capture_enable(capture_enable),
+        .freeze(freeze),
+        .sample_data(sample_data),
+        .read_clk(read_clk),
+        .read_addr(read_addr),
+        .read_data(read_data),
+        .write_ptr(write_ptr)
+    );
+
+    task automatic capture_sample(input logic [DATA_WIDTH-1:0] value);
+        begin
+            @(negedge write_clk);
+            sample_data = value;
+            capture_enable = 1'b1;
+            freeze = 1'b0;
+            @(posedge write_clk);
+            #1;
+            capture_enable = 1'b0;
+        end
+    endtask
+
+    task automatic attempt_write(
+        input logic [DATA_WIDTH-1:0] value,
+        input logic                  enable,
+        input logic                  frozen
+    );
+        begin
+            @(negedge write_clk);
+            sample_data = value;
+            capture_enable = enable;
+            freeze = frozen;
+            @(posedge write_clk);
+            #1;
+            capture_enable = 1'b0;
+            freeze = 1'b0;
+        end
+    endtask
+
+    task automatic expect_memory(
+        input logic [ADDR_WIDTH-1:0] address,
+        input logic [DATA_WIDTH-1:0] value,
+        input string                 label
+    );
+        begin
+            @(negedge read_clk);
+            read_addr = address;
+            @(posedge read_clk);
+            #1;
+
+            if (read_data !== value) begin
+                $error("%s: address %0d got 0x%02x, expected 0x%02x",
+                       label, address, read_data, value);
+                failures++;
+            end
+        end
+    endtask
+
+    task automatic expect_snapshot(input string label);
+        int unsigned address;
+        begin
+            for (address = 0; address < DEPTH; address++) begin
+                expect_memory(ADDR_WIDTH'(address), expected[address], label);
+            end
+        end
+    endtask
+
+    initial begin
+        write_clk = 1'b0;
+        read_clk = 1'b0;
+        reset_n = 1'b0;
+        capture_enable = 1'b0;
+        freeze = 1'b0;
+        sample_data = '0;
+        read_addr = '0;
+        failures = 0;
+
+        repeat (2) @(posedge write_clk);
+        reset_n = 1'b1;
+
+        // Seven writes into a five-entry memory prove explicit circular wrap.
+        capture_sample(8'h10);
+        capture_sample(8'h11);
+        capture_sample(8'h12);
+        capture_sample(8'h13);
+        capture_sample(8'h14);
+        capture_sample(8'h15);
+        capture_sample(8'h16);
+
+        expected[0] = 8'h15;
+        expected[1] = 8'h16;
+        expected[2] = 8'h12;
+        expected[3] = 8'h13;
+        expected[4] = 8'h14;
+
+        if (write_ptr !== ADDR_WIDTH'(2)) begin
+            $error("wrap: write_ptr got %0d, expected 2", write_ptr);
+            failures++;
+        end
+        expect_snapshot("wrapped readback");
+
+        // Freeze is a write gate, not a memory clear or read-port gate.
+        attempt_write(8'haa, 1'b1, 1'b1);
+        if (write_ptr !== ADDR_WIDTH'(2)) begin
+            $error("freeze: write_ptr changed to %0d", write_ptr);
+            failures++;
+        end
+        expect_snapshot("frozen readback");
+
+        // Negative control: changing data with capture disabled must not write.
+        attempt_write(8'hcc, 1'b0, 1'b0);
+        if (write_ptr !== ADDR_WIDTH'(2)) begin
+            $error("disabled capture: write_ptr changed to %0d", write_ptr);
+            failures++;
+        end
+        expect_snapshot("disabled capture");
+
+        if (failures != 0) begin
+            $fatal(1, "capture_channel failed with %0d error(s)", failures);
+        end
+
+        $display("PASS: wrap, freeze, readback, and disabled-capture stability");
+        $finish;
+    end
+
+endmodule

--- a/fpga/sim/tb_debugclk_hw_top.sv
+++ b/fpga/sim/tb_debugclk_hw_top.sv
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+// Validates the hardware wrapper exclusively through its six physical nets,
+// the way the real bench will: no internal observability is assumed.
+module tb_debugclk_hw_top;
+
+    localparam int unsigned FRAME_BYTES = 1026;
+    localparam int unsigned SAMPLE_BYTES = FRAME_BYTES - 3;
+
+    logic dbg_clk;
+    logic run_enable;
+    logic spi_cs_n;
+    logic spi_sclk;
+    logic spi_mosi;
+    wire  spi_so;
+
+    logic [7:0] captured_frame [0:FRAME_BYTES-1];
+    logic [7:0] frame_a [0:FRAME_BYTES-1];
+    logic [7:0] frame_b [0:FRAME_BYTES-1];
+    int unsigned failures;
+
+    always #5 dbg_clk = ~dbg_clk;
+
+    debugclk_hw_top dut (
+        .dbg_clk(dbg_clk),
+        .run_enable(run_enable),
+        .spi_cs_n(spi_cs_n),
+        .spi_sclk(spi_sclk),
+        .spi_mosi(spi_mosi),
+        .spi_so(spi_so)
+    );
+
+    task automatic transfer_byte(
+        input  logic [7:0] mosi_value,
+        output logic [7:0] miso_value
+    );
+        int bit_number;
+        begin
+            miso_value = '0;
+            for (bit_number = 7; bit_number >= 0; bit_number--) begin
+                spi_mosi = mosi_value[bit_number];
+                spi_sclk = 1'b0;
+                #2;
+                spi_sclk = 1'b1;
+                #1;
+                miso_value[bit_number] = spi_so;
+                #1;
+            end
+        end
+    endtask
+
+    // Icarus does not support unpacked-array task ports and silently drops
+    // copy-out to variable-indexed array-element actuals, so bytes land in a
+    // scalar first and are then stored into the shared captured_frame buffer.
+    task automatic read_frame(input logic [7:0] opcode);
+        int unsigned byte_number;
+        logic [7:0] byte_value;
+        begin
+            spi_sclk = 1'b1;
+            spi_cs_n = 1'b0;
+            #2;
+            transfer_byte(opcode, byte_value);
+            captured_frame[0] = byte_value;
+            for (byte_number = 1; byte_number < FRAME_BYTES; byte_number++) begin
+                transfer_byte(8'hff, byte_value);
+                captured_frame[byte_number] = byte_value;
+            end
+            #2;
+            spi_cs_n = 1'b1;
+            #2;
+            if (spi_so !== 1'bz) begin
+                $error("SO kept driving after CS rose");
+                failures++;
+            end
+        end
+    endtask
+
+    function automatic bit is_onehot_or_zero(input logic [7:0] value);
+        return (value == 8'h00) || ((value & (value - 8'h01)) == 8'h00);
+    endfunction
+
+    initial begin
+        dbg_clk = 1'b0;
+        run_enable = 1'b0;
+        spi_cs_n = 1'b1;
+        spi_sclk = 1'b1;
+        spi_mosi = 1'b0;
+        failures = 0;
+
+        // Power-on-reset shifter needs eight debug clocks; give it margin.
+        repeat (16) @(posedge dbg_clk);
+
+        // Stock's observed arm sequence opens with an empty CS pulse; issue
+        // the same pulse here.  On hardware every flop is defined after
+        // configuration; in simulation this pulse also clears the X-state
+        // pessimism in the SPI shifters before the first real frame.
+        spi_cs_n = 1'b0;
+        #4;
+        spi_cs_n = 1'b1;
+        #4;
+
+        // Run the engine long enough for the CH1 ramp to cross the default
+        // 0xAD trigger level and freeze the buffers with deterministic
+        // content: an incrementing CH1 prefix, a walking-one CH2 prefix, and
+        // untouched zeroed BSRAM words past the freeze point.
+        @(negedge dbg_clk);
+        run_enable = 1'b1;
+        repeat (2000) @(posedge dbg_clk);
+
+        read_frame(8'h04);
+        for (int unsigned index = 0; index < FRAME_BYTES; index++) begin
+            frame_a[index] = captured_frame[index];
+        end
+
+        if (frame_a[0] !== 8'h52 || frame_a[1] !== 8'h31 || frame_a[2] !== 8'h56) begin
+            $error("CH1 status markers got %02x %02x %02x, expected 52 31 56",
+                   frame_a[0], frame_a[1], frame_a[2]);
+            failures++;
+        end
+
+        // Structural checks avoid phase math: the sample region must contain a
+        // long strictly-incrementing run and must not be constant.  The
+        // byte-by-byte temporaries also dodge an Icarus miscompile of
+        // $isunknown over loop-indexed array selects inside a conjunction.
+        begin
+            int unsigned longest_run;
+            int unsigned current_run;
+            logic [7:0] this_byte;
+            logic [7:0] next_byte;
+            longest_run = 0;
+            current_run = 0;
+            for (int unsigned index = 3; index < FRAME_BYTES - 1; index++) begin
+                this_byte = frame_a[index];
+                next_byte = frame_a[index + 1];
+                if (!$isunknown(next_byte) && next_byte === (this_byte + 8'h01)) begin
+                    current_run++;
+                    if (current_run > longest_run) begin
+                        longest_run = current_run;
+                    end
+                end else begin
+                    current_run = 0;
+                end
+            end
+            if (longest_run < 64) begin
+                $error("CH1 ramp run too short: %0d consecutive increments", longest_run);
+                failures++;
+            end
+        end
+
+        // Frozen buffer: a second read must be byte-identical while the debug
+        // clock keeps running.
+        repeat (50) @(posedge dbg_clk);
+        read_frame(8'h04);
+        for (int unsigned index = 0; index < FRAME_BYTES; index++) begin
+            frame_b[index] = captured_frame[index];
+        end
+        for (int unsigned index = 0; index < FRAME_BYTES; index++) begin
+            if (frame_a[index] !== frame_b[index]) begin
+                $error("frozen CH1 frame changed at byte %0d: %02x -> %02x",
+                       index, frame_a[index], frame_b[index]);
+                failures++;
+            end
+        end
+
+        // CH2 carries the walking-one marker; every sample byte is one-hot or
+        // an untouched zero word.
+        read_frame(8'h05);
+        for (int unsigned index = 0; index < FRAME_BYTES; index++) begin
+            frame_b[index] = captured_frame[index];
+        end
+        if (frame_b[0] !== 8'h52 || frame_b[1] !== 8'h31 || frame_b[2] !== 8'h56) begin
+            $error("CH2 status markers got %02x %02x %02x, expected 52 31 56",
+                   frame_b[0], frame_b[1], frame_b[2]);
+            failures++;
+        end
+        // Words past the freeze point were never written: configured hardware
+        // reads them as zeroed BSRAM, while simulation reads X because the
+        // reconstruction deliberately models no memory initialization.  Both
+        // count as untouched here.
+        begin
+            int unsigned onehot_count;
+            logic [7:0] sample_byte;
+            onehot_count = 0;
+            for (int unsigned index = 3; index < FRAME_BYTES; index++) begin
+                sample_byte = frame_b[index];
+                if (!$isunknown(sample_byte) && !is_onehot_or_zero(sample_byte)) begin
+                    $error("CH2 byte %0d is not one-hot or zero: %02x",
+                           index, sample_byte);
+                    failures++;
+                end
+                if (!$isunknown(sample_byte) && sample_byte != 8'h00) begin
+                    onehot_count++;
+                end
+            end
+            if (onehot_count < 64) begin
+                $error("CH2 marker prefix too short: %0d non-zero bytes", onehot_count);
+                failures++;
+            end
+        end
+
+        // Re-arm through the run line: dropping and raising run_enable clears
+        // the trigger latch, and a later read shows refreshed content.
+        @(negedge dbg_clk);
+        run_enable = 1'b0;
+        repeat (4) @(posedge dbg_clk);
+        @(negedge dbg_clk);
+        run_enable = 1'b1;
+        repeat (300) @(posedge dbg_clk);
+        read_frame(8'h04);
+        for (int unsigned index = 0; index < FRAME_BYTES; index++) begin
+            frame_b[index] = captured_frame[index];
+        end
+        begin
+            int unsigned changed_bytes;
+            changed_bytes = 0;
+            for (int unsigned index = 3; index < FRAME_BYTES; index++) begin
+                if (frame_a[index] !== frame_b[index]) begin
+                    changed_bytes++;
+                end
+            end
+            if (changed_bytes == 0) begin
+                $error("re-armed capture never refreshed the buffer");
+                failures++;
+            end
+        end
+
+        if (failures != 0) begin
+            $fatal(1, "debugclk_hw_top failed with %0d error(s)", failures);
+        end
+
+        $display("PASS: POR, status markers, ramp capture, trigger freeze stability, walking marker, and run-line re-arm");
+        $finish;
+    end
+
+endmodule

--- a/fpga/sim/tb_fnirsi_2c53t_top.sv
+++ b/fpga/sim/tb_fnirsi_2c53t_top.sv
@@ -265,7 +265,7 @@ module tb_fnirsi_2c53t_top;
         expect_equal8(reg_trigger_level, 8'had, "reset trigger level");
         expect_equal8(reg_raw_01, 8'h08, "reset raw reg 01");
         expect_equal8(reg_raw_02, 8'h03, "reset raw reg 02");
-        expect_equal8(reg_raw_rate_divisor, 8'h00, "reset rate divisor");
+        expect_equal8(reg_raw_rate_divisor, 8'h08, "reset raw rate alias");
 
         // Negative control: disarmed ADC changes do not advance either buffer.
         capture_clock(8'hee, 8'hdd);
@@ -284,7 +284,7 @@ module tb_fnirsi_2c53t_top;
                           8'h80 + 8'(sample_number));
             if (sample_number == 0) begin
                 expect_bit(sample_tick, 1'b1, "first armed sample tick");
-                expect_bit(slow_path_tick, 1'b1, "undivided slow-path tick");
+                expect_bit(slow_path_tick, 1'b0, "legacy 0x08 slow-path phase");
             end
         end
         expect_bit(trigger_seen, 1'b0, "free run leaves trigger clear");
@@ -348,8 +348,9 @@ module tb_fnirsi_2c53t_top;
         end_transaction();
         expect_equal8(reg_trigger_level, 8'h80, "three-byte frame ignored");
 
-        write_register(8'h0b, 8'h03);
-        expect_equal8(reg_raw_rate_divisor, 8'h03, "rate divisor write");
+        write_register(8'h01, 8'h0e);
+        expect_equal8(reg_raw_01, 8'h0e, "raw rate select write");
+        expect_equal8(reg_raw_rate_divisor, 8'h0e, "raw rate alias write");
 
         // Triggered phase: the comparator, not a testbench input, produces the
         // trigger.  Below-level samples seed history, the 0xc0 sample crosses
@@ -380,8 +381,9 @@ module tb_fnirsi_2c53t_top;
             failures++;
         end
 
-        // The SPI-written divisor paces the slow-path tick: divisor 3 gives
-        // one tick every four armed cycles.
+        // The SPI-written 0x0e rate select paces the slow path at half the
+        // 0x0f base interval.  This short smoke loop only checks that it does
+        // not retain the retired raw-divisor placeholder cadence.
         @(negedge sample_clk);
         raw_arm_enable = 1'b0;
         capture_clock(8'h20, 8'h20);
@@ -394,8 +396,8 @@ module tb_fnirsi_2c53t_top;
                 slow_tick_count++;
             end
         end
-        if (slow_tick_count != 2) begin
-            $error("divided slow-path tick count got %0d, expected 2", slow_tick_count);
+        if (slow_tick_count != 0) begin
+            $error("0x0e ladder interval unexpectedly ticked in 8 cycles: %0d", slow_tick_count);
             failures++;
         end
 

--- a/fpga/sim/tb_fnirsi_2c53t_top.sv
+++ b/fpga/sim/tb_fnirsi_2c53t_top.sv
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+module tb_fnirsi_2c53t_top;
+
+    localparam int unsigned DATA_WIDTH = 8;
+    localparam int unsigned CAPTURE_DEPTH = 16;
+    localparam int unsigned CAPTURE_ADDR_WIDTH = $clog2(CAPTURE_DEPTH);
+    localparam int unsigned FRAME_BYTES = 1026;
+    localparam int unsigned SPI_COUNT_WIDTH = 16;
+    localparam int unsigned TIMEBASE_WIDTH = 4;
+
+    logic                              sample_clk;
+    logic                              reset_n;
+    logic [DATA_WIDTH-1:0]             adc_ch1_data;
+    logic [DATA_WIDTH-1:0]             adc_ch2_data;
+    logic                              raw_arm_enable;
+    logic [TIMEBASE_WIDTH-1:0]         raw_interval_minus_one;
+    logic                              raw_trigger_event;
+    logic [7:0]                        raw_response_status0;
+    logic [7:0]                        raw_response_status1;
+    logic [7:0]                        raw_response_status2;
+    logic                              spi_cs_n;
+    logic                              spi_sclk;
+    logic                              spi_mosi;
+    logic                              spi_miso;
+    logic                              spi_miso_oe;
+    logic                              sample_tick;
+    logic                              trigger_pulse;
+    logic                              trigger_seen;
+    logic [CAPTURE_ADDR_WIDTH-1:0]     ch1_write_ptr;
+    logic [CAPTURE_ADDR_WIDTH-1:0]     ch2_write_ptr;
+    logic [7:0]                        spi_opcode;
+    logic                              spi_opcode_valid;
+    logic                              spi_known_read_active;
+    logic [7:0]                        spi_last_opcode;
+    logic                              spi_last_opcode_known;
+    logic [SPI_COUNT_WIDTH-1:0]        spi_last_byte_count;
+    logic                              spi_last_known_frame_valid;
+    logic                              spi_last_known_frame_error;
+    logic                              spi_unknown_byte_valid;
+    logic                              spi_rx_byte_valid;
+    logic [7:0]                        spi_rx_byte;
+    logic [SPI_COUNT_WIDTH-1:0]        spi_rx_byte_index;
+    logic [SPI_COUNT_WIDTH-1:0]        spi_transaction_byte_count;
+
+    logic [7:0]                        received_miso;
+    int unsigned                       failures;
+
+    always #5 sample_clk = ~sample_clk;
+
+    fnirsi_2c53t_top #(
+        .DATA_WIDTH(DATA_WIDTH),
+        .CAPTURE_DEPTH(CAPTURE_DEPTH),
+        .CAPTURE_ADDR_WIDTH(CAPTURE_ADDR_WIDTH),
+        .FRAME_BYTES(FRAME_BYTES),
+        .SPI_COUNT_WIDTH(SPI_COUNT_WIDTH),
+        .TIMEBASE_WIDTH(TIMEBASE_WIDTH)
+    ) dut (
+        .sample_clk(sample_clk),
+        .reset_n(reset_n),
+        .adc_ch1_data(adc_ch1_data),
+        .adc_ch2_data(adc_ch2_data),
+        .raw_arm_enable(raw_arm_enable),
+        .raw_interval_minus_one(raw_interval_minus_one),
+        .raw_trigger_event(raw_trigger_event),
+        .raw_response_status0(raw_response_status0),
+        .raw_response_status1(raw_response_status1),
+        .raw_response_status2(raw_response_status2),
+        .spi_cs_n(spi_cs_n),
+        .spi_sclk(spi_sclk),
+        .spi_mosi(spi_mosi),
+        .spi_miso(spi_miso),
+        .spi_miso_oe(spi_miso_oe),
+        .sample_tick(sample_tick),
+        .trigger_pulse(trigger_pulse),
+        .trigger_seen(trigger_seen),
+        .ch1_write_ptr(ch1_write_ptr),
+        .ch2_write_ptr(ch2_write_ptr),
+        .spi_opcode(spi_opcode),
+        .spi_opcode_valid(spi_opcode_valid),
+        .spi_known_read_active(spi_known_read_active),
+        .spi_last_opcode(spi_last_opcode),
+        .spi_last_opcode_known(spi_last_opcode_known),
+        .spi_last_byte_count(spi_last_byte_count),
+        .spi_last_known_frame_valid(spi_last_known_frame_valid),
+        .spi_last_known_frame_error(spi_last_known_frame_error),
+        .spi_unknown_byte_valid(spi_unknown_byte_valid),
+        .spi_rx_byte_valid(spi_rx_byte_valid),
+        .spi_rx_byte(spi_rx_byte),
+        .spi_rx_byte_index(spi_rx_byte_index),
+        .spi_transaction_byte_count(spi_transaction_byte_count)
+    );
+
+    task automatic expect_equal8(
+        input logic [7:0] actual,
+        input logic [7:0] expected,
+        input string      label
+    );
+        begin
+            if (actual !== expected) begin
+                $error("%s got 0x%02x, expected 0x%02x", label, actual, expected);
+                failures++;
+            end
+        end
+    endtask
+
+    task automatic expect_bit(
+        input logic  actual,
+        input logic  expected,
+        input string label
+    );
+        begin
+            if (actual !== expected) begin
+                $error("%s got %0b, expected %0b", label, actual, expected);
+                failures++;
+            end
+        end
+    endtask
+
+    task automatic capture_clock(
+        input logic [7:0] ch1_value,
+        input logic [7:0] ch2_value,
+        input logic       trigger_event
+    );
+        begin
+            @(negedge sample_clk);
+            adc_ch1_data = ch1_value;
+            adc_ch2_data = ch2_value;
+            raw_trigger_event = trigger_event;
+            @(posedge sample_clk);
+            #1;
+        end
+    endtask
+
+    task automatic begin_transaction;
+        begin
+            spi_sclk = 1'b1;
+            spi_cs_n = 1'b0;
+            #2;
+        end
+    endtask
+
+    task automatic transfer_byte(
+        input  logic [7:0] mosi_value,
+        output logic [7:0] miso_value
+    );
+        int bit_number;
+        begin
+            miso_value = '0;
+            for (bit_number = 7; bit_number >= 0; bit_number--) begin
+                spi_mosi = mosi_value[bit_number];
+                spi_sclk = 1'b0;
+                #2;
+                spi_sclk = 1'b1;
+                #1;
+                miso_value[bit_number] = spi_miso;
+                #1;
+            end
+        end
+    endtask
+
+    task automatic end_transaction;
+        begin
+            #2;
+            spi_cs_n = 1'b1;
+            #2;
+            expect_bit(spi_miso_oe, 1'b0, "MISO output-enable after CS");
+        end
+    endtask
+
+    task automatic read_channel(
+        input logic [7:0] opcode,
+        input logic [7:0] base_sample,
+        input string      label
+    );
+        int unsigned byte_number;
+        logic [7:0] expected_sample;
+        begin
+            begin_transaction();
+            transfer_byte(opcode, received_miso);
+            expect_equal8(received_miso, raw_response_status0, {label, " status0"});
+            expect_equal8(spi_opcode, opcode, {label, " opcode"});
+            expect_bit(spi_opcode_valid, 1'b1, {label, " opcode_valid"});
+            expect_bit(spi_known_read_active, 1'b1, {label, " known_read_active"});
+
+            transfer_byte(8'hff, received_miso);
+            expect_equal8(received_miso, raw_response_status1, {label, " status1"});
+
+            transfer_byte(8'hff, received_miso);
+            expect_equal8(received_miso, raw_response_status2, {label, " status2"});
+
+            for (byte_number = 0; byte_number < CAPTURE_DEPTH; byte_number++) begin
+                transfer_byte(8'hff, received_miso);
+                expected_sample = base_sample + 8'(byte_number);
+                expect_equal8(received_miso, expected_sample, {label, " sample"});
+            end
+
+            for (byte_number = 3 + CAPTURE_DEPTH; byte_number < FRAME_BYTES; byte_number++) begin
+                transfer_byte(8'hff, received_miso);
+            end
+
+            end_transaction();
+            expect_bit(spi_last_opcode_known, 1'b1, {label, " last opcode known"});
+            expect_equal8(spi_last_opcode, opcode, {label, " last opcode"});
+            if (spi_last_byte_count !== SPI_COUNT_WIDTH'(FRAME_BYTES)) begin
+                $error("%s last byte count got %0d, expected %0d",
+                       label, spi_last_byte_count, FRAME_BYTES);
+                failures++;
+            end
+            expect_bit(spi_last_known_frame_valid, 1'b1, {label, " full frame valid"});
+            expect_bit(spi_last_known_frame_error, 1'b0, {label, " full frame error"});
+        end
+    endtask
+
+    initial begin
+        sample_clk = 1'b0;
+        reset_n = 1'b0;
+        adc_ch1_data = '0;
+        adc_ch2_data = '0;
+        raw_arm_enable = 1'b0;
+        raw_interval_minus_one = '0;
+        raw_trigger_event = 1'b0;
+        raw_response_status0 = 8'hd3;
+        raw_response_status1 = 8'h61;
+        raw_response_status2 = 8'hb2;
+        spi_cs_n = 1'b1;
+        spi_sclk = 1'b1;
+        spi_mosi = 1'b0;
+        failures = 0;
+
+        repeat (2) @(posedge sample_clk);
+        reset_n = 1'b1;
+        repeat (2) @(posedge sample_clk);
+
+        // Negative control: disarmed ADC changes do not advance either buffer.
+        capture_clock(8'hee, 8'hdd, 1'b0);
+        if (ch1_write_ptr !== '0 || ch2_write_ptr !== '0) begin
+            $error("disarmed capture advanced write pointers");
+            failures++;
+        end
+
+        // One sample per armed clock.  The trigger event latches and then
+        // freezes later writes; no stock post-trigger policy is invented here.
+        @(negedge sample_clk);
+        raw_arm_enable = 1'b1;
+        raw_interval_minus_one = '0;
+        for (int unsigned sample_number = 0; sample_number < CAPTURE_DEPTH; sample_number++) begin
+            capture_clock(8'h10 + 8'(sample_number),
+                          8'h80 + 8'(sample_number),
+                          sample_number == CAPTURE_DEPTH - 1);
+            if (sample_number == 0) begin
+                expect_bit(sample_tick, 1'b1, "first armed sample tick");
+            end
+        end
+        expect_bit(trigger_seen, 1'b1, "trigger latch");
+        expect_bit(trigger_pulse, 1'b1, "trigger pulse");
+
+        capture_clock(8'h99, 8'ha9, 1'b0);
+        if (ch1_write_ptr !== CAPTURE_ADDR_WIDTH'(0) ||
+            ch2_write_ptr !== CAPTURE_ADDR_WIDTH'(0)) begin
+            $error("trigger freeze did not hold write pointers after a full buffer");
+            failures++;
+        end
+
+        read_channel(8'h04, 8'h10, "CH1 read");
+        read_channel(8'h05, 8'h80, "CH2 read");
+
+        // Unknown opcodes remain raw SPI events and are not upgraded into a
+        // known read response or a frame-length error.
+        begin_transaction();
+        transfer_byte(8'h99, received_miso);
+        expect_equal8(received_miso, raw_response_status0, "unknown status0");
+        expect_equal8(spi_rx_byte, 8'h99, "unknown raw byte");
+        expect_bit(spi_rx_byte_valid, 1'b1, "unknown raw valid");
+        if (spi_rx_byte_index !== SPI_COUNT_WIDTH'(0) ||
+            spi_transaction_byte_count !== SPI_COUNT_WIDTH'(1)) begin
+            $error("unknown raw index/count mismatch");
+            failures++;
+        end
+        expect_bit(spi_unknown_byte_valid, 1'b1, "unknown opcode raw event");
+        transfer_byte(8'ha5, received_miso);
+        expect_equal8(received_miso, 8'h00, "unknown payload response");
+        end_transaction();
+
+        expect_bit(spi_last_opcode_known, 1'b0, "unknown last opcode known");
+        expect_bit(spi_last_known_frame_valid, 1'b0, "unknown frame valid");
+        expect_bit(spi_last_known_frame_error, 1'b0, "unknown frame error");
+        expect_equal8(spi_last_opcode, 8'h99, "unknown last opcode");
+
+        if (failures != 0) begin
+            $fatal(1, "fnirsi_2c53t_top failed with %0d error(s)", failures);
+        end
+
+        $display("PASS: top captures both channels, latches trigger, serves 0x04/0x05 reads, and preserves unknown opcodes");
+        $finish;
+    end
+
+endmodule

--- a/fpga/sim/tb_fnirsi_2c53t_top.sv
+++ b/fpga/sim/tb_fnirsi_2c53t_top.sv
@@ -17,7 +17,6 @@ module tb_fnirsi_2c53t_top;
     logic [DATA_WIDTH-1:0]             adc_ch2_data;
     logic                              raw_arm_enable;
     logic [TIMEBASE_WIDTH-1:0]         raw_interval_minus_one;
-    logic                              raw_trigger_event;
     logic [7:0]                        raw_response_status0;
     logic [7:0]                        raw_response_status1;
     logic [7:0]                        raw_response_status2;
@@ -29,6 +28,14 @@ module tb_fnirsi_2c53t_top;
     logic                              sample_tick;
     logic                              trigger_pulse;
     logic                              trigger_seen;
+    logic                              ch1_at_or_above_level;
+    logic [7:0]                        reg_raw_01;
+    logic [7:0]                        reg_raw_02;
+    logic [7:0]                        reg_raw_06;
+    logic [7:0]                        reg_raw_07;
+    logic [7:0]                        reg_trigger_level;
+    logic [7:0]                        reg_raw_rate_divisor;
+    logic                              slow_path_tick;
     logic [CAPTURE_ADDR_WIDTH-1:0]     ch1_write_ptr;
     logic [CAPTURE_ADDR_WIDTH-1:0]     ch2_write_ptr;
     logic [7:0]                        spi_opcode;
@@ -47,6 +54,7 @@ module tb_fnirsi_2c53t_top;
 
     logic [7:0]                        received_miso;
     int unsigned                       failures;
+    int unsigned                       slow_tick_count;
 
     always #5 sample_clk = ~sample_clk;
 
@@ -64,7 +72,6 @@ module tb_fnirsi_2c53t_top;
         .adc_ch2_data(adc_ch2_data),
         .raw_arm_enable(raw_arm_enable),
         .raw_interval_minus_one(raw_interval_minus_one),
-        .raw_trigger_event(raw_trigger_event),
         .raw_response_status0(raw_response_status0),
         .raw_response_status1(raw_response_status1),
         .raw_response_status2(raw_response_status2),
@@ -76,6 +83,14 @@ module tb_fnirsi_2c53t_top;
         .sample_tick(sample_tick),
         .trigger_pulse(trigger_pulse),
         .trigger_seen(trigger_seen),
+        .ch1_at_or_above_level(ch1_at_or_above_level),
+        .reg_raw_01(reg_raw_01),
+        .reg_raw_02(reg_raw_02),
+        .reg_raw_06(reg_raw_06),
+        .reg_raw_07(reg_raw_07),
+        .reg_trigger_level(reg_trigger_level),
+        .reg_raw_rate_divisor(reg_raw_rate_divisor),
+        .slow_path_tick(slow_path_tick),
         .ch1_write_ptr(ch1_write_ptr),
         .ch2_write_ptr(ch2_write_ptr),
         .spi_opcode(spi_opcode),
@@ -121,14 +136,12 @@ module tb_fnirsi_2c53t_top;
 
     task automatic capture_clock(
         input logic [7:0] ch1_value,
-        input logic [7:0] ch2_value,
-        input logic       trigger_event
+        input logic [7:0] ch2_value
     );
         begin
             @(negedge sample_clk);
             adc_ch1_data = ch1_value;
             adc_ch2_data = ch2_value;
-            raw_trigger_event = trigger_event;
             @(posedge sample_clk);
             #1;
         end
@@ -167,6 +180,20 @@ module tb_fnirsi_2c53t_top;
             spi_cs_n = 1'b1;
             #2;
             expect_bit(spi_miso_oe, 1'b0, "MISO output-enable after CS");
+        end
+    endtask
+
+    // The observed stock write shape: a two-byte CS-low frame carrying a
+    // register select and one value byte.
+    task automatic write_register(
+        input logic [7:0] select_byte,
+        input logic [7:0] value_byte
+    );
+        begin
+            begin_transaction();
+            transfer_byte(select_byte, received_miso);
+            transfer_byte(value_byte, received_miso);
+            end_transaction();
         end
     endtask
 
@@ -221,7 +248,6 @@ module tb_fnirsi_2c53t_top;
         adc_ch2_data = '0;
         raw_arm_enable = 1'b0;
         raw_interval_minus_one = '0;
-        raw_trigger_event = 1'b0;
         raw_response_status0 = 8'hd3;
         raw_response_status1 = 8'h61;
         raw_response_status2 = 8'hb2;
@@ -229,43 +255,61 @@ module tb_fnirsi_2c53t_top;
         spi_sclk = 1'b1;
         spi_mosi = 1'b0;
         failures = 0;
+        slow_tick_count = 0;
 
         repeat (2) @(posedge sample_clk);
         reset_n = 1'b1;
         repeat (2) @(posedge sample_clk);
 
+        // Reset defaults are the stock arm-sequence register values.
+        expect_equal8(reg_trigger_level, 8'had, "reset trigger level");
+        expect_equal8(reg_raw_01, 8'h08, "reset raw reg 01");
+        expect_equal8(reg_raw_02, 8'h03, "reset raw reg 02");
+        expect_equal8(reg_raw_rate_divisor, 8'h00, "reset rate divisor");
+
         // Negative control: disarmed ADC changes do not advance either buffer.
-        capture_clock(8'hee, 8'hdd, 1'b0);
+        capture_clock(8'hee, 8'hdd);
         if (ch1_write_ptr !== '0 || ch2_write_ptr !== '0) begin
             $error("disarmed capture advanced write pointers");
             failures++;
         end
 
-        // One sample per armed clock.  The trigger event latches and then
-        // freezes later writes; no stock post-trigger policy is invented here.
+        // Free-run phase: one sample per armed clock, every CH1 sample below
+        // the default 0xAD trigger level.  The bench-matching expectation is a
+        // full buffer with no trigger activity at all.
         @(negedge sample_clk);
         raw_arm_enable = 1'b1;
-        raw_interval_minus_one = '0;
         for (int unsigned sample_number = 0; sample_number < CAPTURE_DEPTH; sample_number++) begin
             capture_clock(8'h10 + 8'(sample_number),
-                          8'h80 + 8'(sample_number),
-                          sample_number == CAPTURE_DEPTH - 1);
+                          8'h80 + 8'(sample_number));
             if (sample_number == 0) begin
                 expect_bit(sample_tick, 1'b1, "first armed sample tick");
+                expect_bit(slow_path_tick, 1'b1, "undivided slow-path tick");
             end
         end
-        expect_bit(trigger_seen, 1'b1, "trigger latch");
-        expect_bit(trigger_pulse, 1'b1, "trigger pulse");
+        expect_bit(trigger_seen, 1'b0, "free run leaves trigger clear");
+        if (ch1_write_ptr !== '0 || ch2_write_ptr !== '0) begin
+            $error("free-run buffer did not wrap to pointer zero");
+            failures++;
+        end
 
-        capture_clock(8'h99, 8'ha9, 1'b0);
-        if (ch1_write_ptr !== CAPTURE_ADDR_WIDTH'(0) ||
-            ch2_write_ptr !== CAPTURE_ADDR_WIDTH'(0)) begin
-            $error("trigger freeze did not hold write pointers after a full buffer");
+        // Disarm holds the buffer content for a stable readback; the stock CDC
+        // between free-running writes and SPI reads is deliberately not
+        // modeled here.
+        @(negedge sample_clk);
+        raw_arm_enable = 1'b0;
+        capture_clock(8'h99, 8'ha9);
+        if (ch1_write_ptr !== '0 || ch2_write_ptr !== '0) begin
+            $error("disarm did not stop capture writes");
             failures++;
         end
 
         read_channel(8'h04, 8'h10, "CH1 read");
         read_channel(8'h05, 8'h80, "CH2 read");
+
+        // Bench alias fact: the design decodes only the low five opcode bits,
+        // so 0x24 serves the same CH1 read as 0x04.
+        read_channel(8'h24, 8'h10, "CH1 alias read");
 
         // Unknown opcodes remain raw SPI events and are not upgraded into a
         // known read response or a frame-length error.
@@ -288,12 +332,78 @@ module tb_fnirsi_2c53t_top;
         expect_bit(spi_last_known_frame_valid, 1'b0, "unknown frame valid");
         expect_bit(spi_last_known_frame_error, 1'b0, "unknown frame error");
         expect_equal8(spi_last_opcode, 8'h99, "unknown last opcode");
+        expect_equal8(reg_trigger_level, 8'had, "unexposed register write left trigger level");
+
+        // Register writes use the observed two-byte frame shape.
+        write_register(8'h08, 8'h80);
+        expect_equal8(reg_trigger_level, 8'h80, "trigger level write");
+        write_register(8'h22, 8'h55);
+        expect_equal8(reg_raw_02, 8'h55, "aliased raw register write");
+
+        // Negative control: a three-byte unknown frame must not commit.
+        begin_transaction();
+        transfer_byte(8'h08, received_miso);
+        transfer_byte(8'hee, received_miso);
+        transfer_byte(8'hff, received_miso);
+        end_transaction();
+        expect_equal8(reg_trigger_level, 8'h80, "three-byte frame ignored");
+
+        write_register(8'h0b, 8'h03);
+        expect_equal8(reg_raw_rate_divisor, 8'h03, "rate divisor write");
+
+        // Triggered phase: the comparator, not a testbench input, produces the
+        // trigger.  Below-level samples seed history, the 0xc0 sample crosses
+        // the written 0x80 level, the latch lands one cycle later (writing one
+        // post-crossing sample), and the freeze then holds both pointers.  No
+        // stock post-trigger policy is claimed by this sequencing.
+        @(negedge sample_clk);
+        raw_arm_enable = 1'b1;
+        capture_clock(8'h20, 8'h20);
+        capture_clock(8'h20, 8'h20);
+        capture_clock(8'hc0, 8'h20);
+        expect_bit(trigger_seen, 1'b0, "crossing latch is registered");
+        expect_bit(ch1_at_or_above_level, 1'b1, "comparator saw the crossing sample");
+        capture_clock(8'h20, 8'h20);
+        expect_bit(trigger_pulse, 1'b1, "trigger pulse");
+        expect_bit(trigger_seen, 1'b1, "trigger latch");
+        capture_clock(8'h33, 8'h33);
+        expect_bit(trigger_pulse, 1'b0, "trigger pulse is one cycle");
+        if (ch1_write_ptr !== CAPTURE_ADDR_WIDTH'(4) ||
+            ch2_write_ptr !== CAPTURE_ADDR_WIDTH'(4)) begin
+            $error("trigger freeze did not hold write pointers");
+            failures++;
+        end
+        capture_clock(8'h44, 8'h44);
+        if (ch1_write_ptr !== CAPTURE_ADDR_WIDTH'(4) ||
+            ch2_write_ptr !== CAPTURE_ADDR_WIDTH'(4)) begin
+            $error("frozen write pointers moved");
+            failures++;
+        end
+
+        // The SPI-written divisor paces the slow-path tick: divisor 3 gives
+        // one tick every four armed cycles.
+        @(negedge sample_clk);
+        raw_arm_enable = 1'b0;
+        capture_clock(8'h20, 8'h20);
+        @(negedge sample_clk);
+        raw_arm_enable = 1'b1;
+        slow_tick_count = 0;
+        for (int unsigned cycle_number = 0; cycle_number < 8; cycle_number++) begin
+            capture_clock(8'h20, 8'h20);
+            if (slow_path_tick) begin
+                slow_tick_count++;
+            end
+        end
+        if (slow_tick_count != 2) begin
+            $error("divided slow-path tick count got %0d, expected 2", slow_tick_count);
+            failures++;
+        end
 
         if (failures != 0) begin
             $fatal(1, "fnirsi_2c53t_top failed with %0d error(s)", failures);
         end
 
-        $display("PASS: top captures both channels, latches trigger, serves 0x04/0x05 reads, and preserves unknown opcodes");
+        $display("PASS: free-run capture, register writes, comparator trigger, alias reads, divided slow-path tick, and raw unknown opcodes");
         $finish;
     end
 

--- a/fpga/sim/tb_rate_divider.sv
+++ b/fpga/sim/tb_rate_divider.sv
@@ -4,12 +4,12 @@
 
 module tb_rate_divider;
 
-    localparam int unsigned DIVISOR_WIDTH = 8;
+    localparam int unsigned DIVISOR_WIDTH = 16;
 
     logic                     clk;
     logic                     reset_n;
     logic                     enable;
-    logic [DIVISOR_WIDTH-1:0] raw_divisor;
+    logic [7:0]               raw_divisor;
     logic                     divided_tick;
 
     int unsigned failures;
@@ -17,7 +17,10 @@ module tb_rate_divider;
     always #5 clk = ~clk;
 
     rate_divider #(
-        .DIVISOR_WIDTH(DIVISOR_WIDTH)
+        .SELECT_WIDTH(8),
+        .DIVISOR_WIDTH(DIVISOR_WIDTH),
+        .BASE_DIVISOR(16'd99),
+        .LEGACY_SLOW_DEFAULT_DIVISOR(16'd3)
     ) dut (
         .clk(clk),
         .reset_n(reset_n),
@@ -45,7 +48,7 @@ module tb_rate_divider;
         clk = 1'b0;
         reset_n = 1'b0;
         enable = 1'b0;
-        raw_divisor = DIVISOR_WIDTH'(3);
+        raw_divisor = 8'h08;
         failures = 0;
 
         repeat (2) @(posedge clk);
@@ -56,7 +59,7 @@ module tb_rate_divider;
         clock_and_expect(1'b0, "disabled cycle 1");
         clock_and_expect(1'b0, "disabled cycle 2");
 
-        // Divisor 3 means one tick every four enabled cycles.
+        // 0x08 retains the old slow-default interval (divisor 3 => 4 cycles).
         @(negedge clk);
         enable = 1'b1;
         clock_and_expect(1'b0, "phase 0");
@@ -79,21 +82,42 @@ module tb_rate_divider;
         clock_and_expect(1'b0, "restarted phase 2");
         clock_and_expect(1'b1, "restarted phase 3 tick");
 
-        // Divisor 0 is the declared undivided default: a tick every cycle.
+        // 0x0f is the measured 30 kS/s base interval; with BASE_DIVISOR=99
+        // this is 100 cycles including the terminal count.
         @(negedge clk);
         enable = 1'b0;
-        raw_divisor = '0;
+        raw_divisor = 8'h0f;
         clock_and_expect(1'b0, "zero divisor while disabled");
         @(negedge clk);
         enable = 1'b1;
-        clock_and_expect(1'b1, "zero divisor cycle 1");
-        clock_and_expect(1'b1, "zero divisor cycle 2");
+        repeat (99) clock_and_expect(1'b0, "0f base interval");
+        clock_and_expect(1'b1, "0f base tick");
+
+        // 0x0e is twice the measured rate, hence half the divider interval.
+        @(negedge clk);
+        enable = 1'b0;
+        raw_divisor = 8'h0e;
+        clock_and_expect(1'b0, "0e disabled");
+        @(negedge clk);
+        enable = 1'b1;
+        repeat (49) clock_and_expect(1'b0, "0e interval");
+        clock_and_expect(1'b1, "0e tick");
+
+        // 0x10 is the measured 15 kS/s further-slow step (2x the 0f divisor).
+        @(negedge clk);
+        enable = 1'b0;
+        raw_divisor = 8'h10;
+        clock_and_expect(1'b0, "10 disabled");
+        @(negedge clk);
+        enable = 1'b1;
+        repeat (198) clock_and_expect(1'b0, "10 interval");
+        clock_and_expect(1'b1, "10 tick");
 
         if (failures != 0) begin
             $fatal(1, "rate_divider failed with %0d error(s)", failures);
         end
 
-        $display("PASS: divided cadence, disable reset, and undivided default");
+        $display("PASS: legacy mode, measured ladder decode, disable reset, and 15 kS/s step");
         $finish;
     end
 

--- a/fpga/sim/tb_rate_divider.sv
+++ b/fpga/sim/tb_rate_divider.sv
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+module tb_rate_divider;
+
+    localparam int unsigned DIVISOR_WIDTH = 8;
+
+    logic                     clk;
+    logic                     reset_n;
+    logic                     enable;
+    logic [DIVISOR_WIDTH-1:0] raw_divisor;
+    logic                     divided_tick;
+
+    int unsigned failures;
+
+    always #5 clk = ~clk;
+
+    rate_divider #(
+        .DIVISOR_WIDTH(DIVISOR_WIDTH)
+    ) dut (
+        .clk(clk),
+        .reset_n(reset_n),
+        .enable(enable),
+        .raw_divisor(raw_divisor),
+        .divided_tick(divided_tick)
+    );
+
+    task automatic clock_and_expect(
+        input logic  expected_tick,
+        input string label
+    );
+        begin
+            @(posedge clk);
+            #1;
+            if (divided_tick !== expected_tick) begin
+                $error("%s: divided_tick got %b, expected %b",
+                       label, divided_tick, expected_tick);
+                failures++;
+            end
+        end
+    endtask
+
+    initial begin
+        clk = 1'b0;
+        reset_n = 1'b0;
+        enable = 1'b0;
+        raw_divisor = DIVISOR_WIDTH'(3);
+        failures = 0;
+
+        repeat (2) @(posedge clk);
+        #1;
+        reset_n = 1'b1;
+
+        // Negative control: a disabled divider never ticks.
+        clock_and_expect(1'b0, "disabled cycle 1");
+        clock_and_expect(1'b0, "disabled cycle 2");
+
+        // Divisor 3 means one tick every four enabled cycles.
+        @(negedge clk);
+        enable = 1'b1;
+        clock_and_expect(1'b0, "phase 0");
+        clock_and_expect(1'b0, "phase 1");
+        clock_and_expect(1'b0, "phase 2");
+        clock_and_expect(1'b1, "phase 3 tick");
+        clock_and_expect(1'b0, "next phase 0");
+        clock_and_expect(1'b0, "next phase 1");
+        clock_and_expect(1'b0, "next phase 2");
+        clock_and_expect(1'b1, "next phase 3 tick");
+
+        // Disable clears the phase; re-enable restarts a full interval.
+        @(negedge clk);
+        enable = 1'b0;
+        clock_and_expect(1'b0, "disable mid-interval");
+        @(negedge clk);
+        enable = 1'b1;
+        clock_and_expect(1'b0, "restarted phase 0");
+        clock_and_expect(1'b0, "restarted phase 1");
+        clock_and_expect(1'b0, "restarted phase 2");
+        clock_and_expect(1'b1, "restarted phase 3 tick");
+
+        // Divisor 0 is the declared undivided default: a tick every cycle.
+        @(negedge clk);
+        enable = 1'b0;
+        raw_divisor = '0;
+        clock_and_expect(1'b0, "zero divisor while disabled");
+        @(negedge clk);
+        enable = 1'b1;
+        clock_and_expect(1'b1, "zero divisor cycle 1");
+        clock_and_expect(1'b1, "zero divisor cycle 2");
+
+        if (failures != 0) begin
+            $fatal(1, "rate_divider failed with %0d error(s)", failures);
+        end
+
+        $display("PASS: divided cadence, disable reset, and undivided default");
+        $finish;
+    end
+
+endmodule

--- a/fpga/sim/tb_spi_control_registers.sv
+++ b/fpga/sim/tb_spi_control_registers.sv
@@ -94,7 +94,7 @@ module tb_spi_control_registers;
         expect_reg(raw_reg_06, 8'h00, "reset raw_reg_06");
         expect_reg(raw_reg_07, 8'h00, "reset raw_reg_07");
         expect_reg(trigger_level, 8'had, "reset trigger_level");
-        expect_reg(raw_rate_divisor, 8'h00, "reset raw_rate_divisor");
+        expect_reg(raw_rate_divisor, 8'h08, "raw rate alias follows raw_reg_01");
 
         // A two-byte unknown frame commits its register.
         close_frame(8'h08, 1'b0, COUNT_WIDTH'(2), 8'h80);
@@ -114,15 +114,12 @@ module tb_spi_control_registers;
         expect_reg(raw_reg_01, 8'h08, "known read left raw_reg_01");
         expect_reg(trigger_level, 8'h80, "known read left trigger_level");
 
-        // The placeholder rate-divisor select accepts a write.
-        close_frame(8'h0b, 1'b0, COUNT_WIDTH'(2), 8'h16);
-        expect_reg(raw_rate_divisor, 8'h16, "rate divisor write");
-
         // The remaining stock arm registers store raw values.
         close_frame(8'h01, 1'b0, COUNT_WIDTH'(2), 8'ha1);
         close_frame(8'h06, 1'b0, COUNT_WIDTH'(2), 8'ha6);
         close_frame(8'h07, 1'b0, COUNT_WIDTH'(2), 8'ha7);
         expect_reg(raw_reg_01, 8'ha1, "raw_reg_01 write");
+        expect_reg(raw_rate_divisor, 8'ha1, "raw rate alias after raw_reg_01 write");
         expect_reg(raw_reg_06, 8'ha6, "raw_reg_06 write");
         expect_reg(raw_reg_07, 8'ha7, "raw_reg_07 write");
 

--- a/fpga/sim/tb_spi_control_registers.sv
+++ b/fpga/sim/tb_spi_control_registers.sv
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+module tb_spi_control_registers;
+
+    localparam int unsigned COUNT_WIDTH = 16;
+
+    logic                   reset_n;
+    logic                   spi_cs_n;
+    logic [7:0]             opcode;
+    logic                   opcode_valid;
+    logic                   known_read_active;
+    logic [COUNT_WIDTH-1:0] transaction_byte_count;
+    logic [7:0]             rx_byte;
+    logic [7:0]             raw_reg_01;
+    logic [7:0]             raw_reg_02;
+    logic [7:0]             raw_reg_06;
+    logic [7:0]             raw_reg_07;
+    logic [7:0]             trigger_level;
+    logic [7:0]             raw_rate_divisor;
+
+    int unsigned failures;
+
+    spi_control_registers #(
+        .COUNT_WIDTH(COUNT_WIDTH)
+    ) dut (
+        .reset_n(reset_n),
+        .spi_cs_n(spi_cs_n),
+        .opcode_select(opcode[4:0]),
+        .opcode_valid(opcode_valid),
+        .known_read_active(known_read_active),
+        .transaction_byte_count(transaction_byte_count),
+        .rx_byte(rx_byte),
+        .raw_reg_01(raw_reg_01),
+        .raw_reg_02(raw_reg_02),
+        .raw_reg_06(raw_reg_06),
+        .raw_reg_07(raw_reg_07),
+        .trigger_level(trigger_level),
+        .raw_rate_divisor(raw_rate_divisor)
+    );
+
+    task automatic expect_reg(
+        input logic [7:0] actual,
+        input logic [7:0] expected,
+        input string      label
+    );
+        begin
+            if (actual !== expected) begin
+                $error("%s got 0x%02x, expected 0x%02x", label, actual, expected);
+                failures++;
+            end
+        end
+    endtask
+
+    // Models the state the SPI frontend presents at a transaction boundary.
+    task automatic close_frame(
+        input logic [7:0]             frame_opcode,
+        input logic                   frame_known_read,
+        input logic [COUNT_WIDTH-1:0] frame_byte_count,
+        input logic [7:0]             frame_last_byte
+    );
+        begin
+            spi_cs_n = 1'b0;
+            #2;
+            opcode = frame_opcode;
+            opcode_valid = 1'b1;
+            known_read_active = frame_known_read;
+            transaction_byte_count = frame_byte_count;
+            rx_byte = frame_last_byte;
+            #2;
+            spi_cs_n = 1'b1;
+            #2;
+        end
+    endtask
+
+    initial begin
+        reset_n = 1'b0;
+        spi_cs_n = 1'b1;
+        opcode = '0;
+        opcode_valid = 1'b0;
+        known_read_active = 1'b0;
+        transaction_byte_count = '0;
+        rx_byte = '0;
+        failures = 0;
+
+        #4;
+        reset_n = 1'b1;
+        #4;
+
+        // Reset defaults are the stock arm-sequence values.
+        expect_reg(raw_reg_01, 8'h08, "reset raw_reg_01");
+        expect_reg(raw_reg_02, 8'h03, "reset raw_reg_02");
+        expect_reg(raw_reg_06, 8'h00, "reset raw_reg_06");
+        expect_reg(raw_reg_07, 8'h00, "reset raw_reg_07");
+        expect_reg(trigger_level, 8'had, "reset trigger_level");
+        expect_reg(raw_rate_divisor, 8'h00, "reset raw_rate_divisor");
+
+        // A two-byte unknown frame commits its register.
+        close_frame(8'h08, 1'b0, COUNT_WIDTH'(2), 8'h80);
+        expect_reg(trigger_level, 8'h80, "trigger level write");
+
+        // The low-five-bit select hypothesis: 0x22 commits register 0x02.
+        close_frame(8'h22, 1'b0, COUNT_WIDTH'(2), 8'h55);
+        expect_reg(raw_reg_02, 8'h55, "aliased raw_reg_02 write");
+
+        // Negative controls: wrong-length frames and known channel reads must
+        // not commit anything.
+        close_frame(8'h08, 1'b0, COUNT_WIDTH'(3), 8'hee);
+        expect_reg(trigger_level, 8'h80, "three-byte frame ignored");
+        close_frame(8'h08, 1'b0, COUNT_WIDTH'(1), 8'hee);
+        expect_reg(trigger_level, 8'h80, "one-byte frame ignored");
+        close_frame(8'h04, 1'b1, COUNT_WIDTH'(2), 8'hee);
+        expect_reg(raw_reg_01, 8'h08, "known read left raw_reg_01");
+        expect_reg(trigger_level, 8'h80, "known read left trigger_level");
+
+        // The placeholder rate-divisor select accepts a write.
+        close_frame(8'h0b, 1'b0, COUNT_WIDTH'(2), 8'h16);
+        expect_reg(raw_rate_divisor, 8'h16, "rate divisor write");
+
+        // The remaining stock arm registers store raw values.
+        close_frame(8'h01, 1'b0, COUNT_WIDTH'(2), 8'ha1);
+        close_frame(8'h06, 1'b0, COUNT_WIDTH'(2), 8'ha6);
+        close_frame(8'h07, 1'b0, COUNT_WIDTH'(2), 8'ha7);
+        expect_reg(raw_reg_01, 8'ha1, "raw_reg_01 write");
+        expect_reg(raw_reg_06, 8'ha6, "raw_reg_06 write");
+        expect_reg(raw_reg_07, 8'ha7, "raw_reg_07 write");
+
+        if (failures != 0) begin
+            $fatal(1, "spi_control_registers failed with %0d error(s)", failures);
+        end
+
+        $display("PASS: reset defaults, two-byte commits, aliased select, and length/known-read negative controls");
+        $finish;
+    end
+
+endmodule

--- a/fpga/sim/tb_spi_runtime_interface.sv
+++ b/fpga/sim/tb_spi_runtime_interface.sv
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+module tb_spi_runtime_interface;
+
+    localparam int unsigned FRAME_BYTES = 1026;
+    localparam int unsigned COUNT_WIDTH = 16;
+
+    logic                   reset_n;
+    logic                   spi_cs_n;
+    logic                   spi_sclk;
+    logic                   spi_mosi;
+    logic                   spi_miso;
+    logic                   spi_miso_oe;
+    logic [7:0]             first_response_byte;
+    logic [7:0]             response_data;
+    logic [COUNT_WIDTH-1:0] response_byte_index;
+    logic [1:0]             response_channel;
+    logic                   rx_byte_valid;
+    logic [7:0]             rx_byte;
+    logic [COUNT_WIDTH-1:0] rx_byte_index;
+    logic                   unknown_byte_valid;
+    logic [7:0]             opcode;
+    logic                   opcode_valid;
+    logic                   known_read_active;
+    logic [COUNT_WIDTH-1:0] transaction_byte_count;
+    logic [7:0]             last_opcode;
+    logic                   last_opcode_known;
+    logic [COUNT_WIDTH-1:0] last_byte_count;
+    logic                   last_known_frame_valid;
+    logic                   last_known_frame_error;
+
+    logic [7:0] received_miso;
+    logic [7:0] raw_bytes [0:FRAME_BYTES+3];
+    logic       raw_unknown [0:FRAME_BYTES+3];
+    int unsigned raw_count;
+    int unsigned failures;
+
+    spi_runtime_interface #(
+        .FRAME_BYTES(FRAME_BYTES),
+        .COUNT_WIDTH(COUNT_WIDTH)
+    ) dut (
+        .reset_n(reset_n),
+        .spi_cs_n(spi_cs_n),
+        .spi_sclk(spi_sclk),
+        .spi_mosi(spi_mosi),
+        .spi_miso(spi_miso),
+        .spi_miso_oe(spi_miso_oe),
+        .first_response_byte(first_response_byte),
+        .response_data(response_data),
+        .response_byte_index(response_byte_index),
+        .response_channel(response_channel),
+        .rx_byte_valid(rx_byte_valid),
+        .rx_byte(rx_byte),
+        .rx_byte_index(rx_byte_index),
+        .unknown_byte_valid(unknown_byte_valid),
+        .opcode(opcode),
+        .opcode_valid(opcode_valid),
+        .known_read_active(known_read_active),
+        .transaction_byte_count(transaction_byte_count),
+        .last_opcode(last_opcode),
+        .last_opcode_known(last_opcode_known),
+        .last_byte_count(last_byte_count),
+        .last_known_frame_valid(last_known_frame_valid),
+        .last_known_frame_error(last_known_frame_error)
+    );
+
+    // Status semantics are deliberately opaque.  The distinct patterns make
+    // byte positions observable without assigning meaning to their contents.
+    always_comb begin
+        case (response_channel)
+            2'd0: response_data = 8'he0 ^ 8'(response_byte_index);
+            default: begin
+                case (response_byte_index)
+                    16'd1: response_data = 8'h61;
+                    16'd2: response_data = 8'hb2;
+                    default: begin
+                        case (response_channel)
+                    2'd1: response_data = 8'h40 ^ 8'(response_byte_index - 3);
+                    2'd2: response_data = 8'h80 ^ 8'(response_byte_index - 3);
+                            default: response_data = 'x;
+                        endcase
+                    end
+                endcase
+            end
+        endcase
+    end
+
+    task automatic begin_transaction;
+        begin
+            raw_count = 0;
+            spi_sclk = 1'b1;
+            spi_cs_n = 1'b0;
+            #2;
+        end
+    endtask
+
+    task automatic transfer_byte(
+        input  logic [7:0] mosi_value,
+        output logic [7:0] miso_value
+    );
+        int bit_number;
+        begin
+            miso_value = '0;
+            for (bit_number = 7; bit_number >= 0; bit_number--) begin
+                spi_mosi = mosi_value[bit_number];
+                spi_sclk = 1'b0;
+                #2;
+                spi_sclk = 1'b1;
+                #1;
+                miso_value[bit_number] = spi_miso;
+                #1;
+            end
+
+            if (!rx_byte_valid || rx_byte !== mosi_value) begin
+                $error("raw receive got valid=%0b byte=0x%02x, expected 0x%02x",
+                       rx_byte_valid, rx_byte, mosi_value);
+                failures++;
+            end
+            raw_bytes[raw_count] = rx_byte;
+            raw_unknown[raw_count] = unknown_byte_valid;
+            if (rx_byte_index !== COUNT_WIDTH'(raw_count)) begin
+                $error("raw index got %0d, expected %0d", rx_byte_index, raw_count);
+                failures++;
+            end
+            raw_count++;
+        end
+    endtask
+
+    task automatic end_transaction;
+        begin
+            #2;
+            spi_cs_n = 1'b1;
+            #2;
+            if (spi_miso_oe !== 1'b0) begin
+                $error("MISO output-enable remained asserted after CS rose");
+                failures++;
+            end
+        end
+    endtask
+
+    task automatic expect_byte(
+        input logic [7:0] actual,
+        input logic [7:0] expected,
+        input string      label
+    );
+        begin
+            if (actual !== expected) begin
+                $error("%s got 0x%02x, expected 0x%02x", label, actual, expected);
+                failures++;
+            end
+        end
+    endtask
+
+    task automatic read_known_frame(input logic [7:0] requested_opcode);
+        int unsigned byte_number;
+        logic [7:0] expected_sample;
+        begin
+            begin_transaction();
+            transfer_byte(requested_opcode, received_miso);
+            expect_byte(received_miso, first_response_byte, "status byte 0");
+            if (!opcode_valid || opcode !== requested_opcode ||
+                !known_read_active || transaction_byte_count !== 16'd1) begin
+                $error("opcode 0x%02x was not latched after byte zero", requested_opcode);
+                failures++;
+            end
+
+            transfer_byte(8'hff, received_miso);
+            expect_byte(received_miso, 8'h61, "status byte 1");
+            transfer_byte(8'hff, received_miso);
+            expect_byte(received_miso, 8'hb2, "status byte 2");
+
+            for (byte_number = 3; byte_number < FRAME_BYTES; byte_number++) begin
+                transfer_byte(8'hff, received_miso);
+                expected_sample = ((requested_opcode == 8'h04) ? 8'h40 : 8'h80) ^
+                                  8'(byte_number - 3);
+                expect_byte(received_miso, expected_sample, "sample byte");
+            end
+            end_transaction();
+
+            if (!last_opcode_known || last_opcode !== requested_opcode ||
+                last_byte_count !== COUNT_WIDTH'(FRAME_BYTES) ||
+                !last_known_frame_valid || last_known_frame_error) begin
+                $error("full known frame metadata mismatch for opcode 0x%02x", requested_opcode);
+                failures++;
+            end
+            if (raw_count != FRAME_BYTES || raw_bytes[0] !== requested_opcode ||
+                raw_bytes[FRAME_BYTES-1] !== 8'hff) begin
+                $error("raw stream mismatch for opcode 0x%02x", requested_opcode);
+                failures++;
+            end
+        end
+    endtask
+
+    initial begin
+        reset_n = 1'b0;
+        spi_cs_n = 1'b1;
+        spi_sclk = 1'b1;
+        spi_mosi = 1'b0;
+        first_response_byte = 8'hd3;
+        raw_count = 0;
+        failures = 0;
+
+        #4;
+        reset_n = 1'b1;
+        #4;
+
+        read_known_frame(8'h04);
+        read_known_frame(8'h05);
+
+        // Negative control: 0x05 is not accepted as CH2 unless CS stays low
+        // for the complete observed 1026-byte runtime window.
+        begin_transaction();
+        transfer_byte(8'h05, received_miso);
+        transfer_byte(8'hff, received_miso);
+        end_transaction();
+        if (!last_opcode_known || last_byte_count !== 16'd2 ||
+            last_known_frame_valid || !last_known_frame_error) begin
+            $error("short 0x05 transaction was not rejected");
+            failures++;
+        end
+
+        // Unknown opcodes and payload bytes remain visible byte-for-byte.  They
+        // are not misclassified as malformed known channel reads.
+        begin_transaction();
+        transfer_byte(8'h99, received_miso);
+        expect_byte(received_miso, first_response_byte, "unknown response byte 0");
+        transfer_byte(8'ha5, received_miso);
+        expect_byte(received_miso, 8'he1, "unknown response byte 1 passthrough");
+        transfer_byte(8'h5a, received_miso);
+        expect_byte(received_miso, 8'he2, "unknown response byte 2 passthrough");
+        end_transaction();
+        if (last_opcode_known || last_known_frame_valid || last_known_frame_error ||
+            last_byte_count !== 16'd3 || raw_count != 3 ||
+            raw_bytes[0] !== 8'h99 || raw_bytes[1] !== 8'ha5 || raw_bytes[2] !== 8'h5a ||
+            !raw_unknown[0] || !raw_unknown[1] || !raw_unknown[2]) begin
+            $error("unknown command was decoded or its raw payload was lost");
+            failures++;
+        end
+
+        // CS is the frame boundary: two single-byte transactions must never be
+        // merged into one apparent two-byte command.
+        begin_transaction();
+        transfer_byte(8'h04, received_miso);
+        end_transaction();
+        if (last_byte_count !== 16'd1 || !last_known_frame_error) begin
+            $error("first CS-delimited byte was not its own short frame");
+            failures++;
+        end
+        begin_transaction();
+        transfer_byte(8'hff, received_miso);
+        end_transaction();
+        if (last_byte_count !== 16'd1 || last_opcode_known ||
+            last_known_frame_valid || last_known_frame_error) begin
+            $error("second CS-delimited byte inherited the previous opcode");
+            failures++;
+        end
+
+        if (failures != 0) begin
+            $fatal(1, "spi_runtime_interface failed with %0d error(s)", failures);
+        end
+
+        $display("PASS: CS framing, opcode latch, 1026-byte counts, MISO sequencing, and unknown raw payloads");
+        $finish;
+    end
+
+endmodule

--- a/fpga/sim/tb_spi_runtime_interface.sv
+++ b/fpga/sim/tb_spi_runtime_interface.sv
@@ -173,7 +173,7 @@ module tb_spi_runtime_interface;
 
             for (byte_number = 3; byte_number < FRAME_BYTES; byte_number++) begin
                 transfer_byte(8'hff, received_miso);
-                expected_sample = ((requested_opcode == 8'h04) ? 8'h40 : 8'h80) ^
+                expected_sample = ((requested_opcode[4:0] == 5'h04) ? 8'h40 : 8'h80) ^
                                   8'(byte_number - 3);
                 expect_byte(received_miso, expected_sample, "sample byte");
             end
@@ -208,6 +208,11 @@ module tb_spi_runtime_interface;
 
         read_known_frame(8'h04);
         read_known_frame(8'h05);
+
+        // Bench alias fact (2026-08-14): only the low five opcode bits are
+        // decoded, so 0x24 must behave exactly as the CH1 read while the raw
+        // opcode byte stays visible unmodified.
+        read_known_frame(8'h24);
 
         // Negative control: 0x05 is not accepted as CH2 unless CS stays low
         // for the complete observed 1026-byte runtime window.

--- a/fpga/sim/tb_trigger_comparator.sv
+++ b/fpga/sim/tb_trigger_comparator.sv
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+module tb_trigger_comparator;
+
+    localparam int unsigned DATA_WIDTH = 8;
+
+    logic                  clk;
+    logic                  reset_n;
+    logic                  arm_enable;
+    logic                  sample_valid;
+    logic [DATA_WIDTH-1:0] sample_data;
+    logic [DATA_WIDTH-1:0] trigger_level;
+    logic                  at_or_above_level;
+    logic                  crossing_event;
+
+    int unsigned failures;
+
+    always #5 clk = ~clk;
+
+    trigger_comparator #(
+        .DATA_WIDTH(DATA_WIDTH)
+    ) dut (
+        .clk(clk),
+        .reset_n(reset_n),
+        .arm_enable(arm_enable),
+        .sample_valid(sample_valid),
+        .sample_data(sample_data),
+        .trigger_level(trigger_level),
+        .at_or_above_level(at_or_above_level),
+        .crossing_event(crossing_event)
+    );
+
+    task automatic sample_and_expect(
+        input logic [DATA_WIDTH-1:0] value,
+        input logic                  valid,
+        input logic                  expected_above,
+        input logic                  expected_crossing,
+        input string                 label
+    );
+        begin
+            @(negedge clk);
+            sample_data = value;
+            sample_valid = valid;
+            @(posedge clk);
+            #1;
+            if (at_or_above_level !== expected_above) begin
+                $error("%s: at_or_above_level got %b, expected %b",
+                       label, at_or_above_level, expected_above);
+                failures++;
+            end
+            if (crossing_event !== expected_crossing) begin
+                $error("%s: crossing_event got %b, expected %b",
+                       label, crossing_event, expected_crossing);
+                failures++;
+            end
+        end
+    endtask
+
+    initial begin
+        clk = 1'b0;
+        reset_n = 1'b0;
+        arm_enable = 1'b0;
+        sample_valid = 1'b0;
+        sample_data = '0;
+        // The bench-anchored case: stock's armed level is 0xAD (173).
+        trigger_level = 8'had;
+        failures = 0;
+
+        repeat (2) @(posedge clk);
+        #1;
+        reset_n = 1'b1;
+
+        // Negative control: disarmed samples above the level do nothing.
+        sample_and_expect(8'hf0, 1'b1, 1'b0, 1'b0, "disarmed above level");
+
+        // The first armed sample only seeds history, even when it is already
+        // at or above the level; no crossing may fire without a prior
+        // below-level sample.
+        @(negedge clk);
+        arm_enable = 1'b1;
+        sample_and_expect(8'hf0, 1'b1, 1'b1, 1'b0, "seed sample above level");
+        sample_and_expect(8'hf0, 1'b1, 1'b1, 1'b0, "held above level");
+
+        // Quiet-noise regime: samples below 0xAD never produce events, the
+        // bench observation behind stock's zero edge rate at level 0xAD.
+        sample_and_expect(8'h52, 1'b1, 1'b0, 1'b0, "noise floor low");
+        sample_and_expect(8'h65, 1'b1, 1'b0, 1'b0, "noise floor high");
+
+        // A rising crossing fires exactly one event and then holds.
+        sample_and_expect(8'hc0, 1'b1, 1'b1, 1'b1, "rising crossing");
+        sample_and_expect(8'hc4, 1'b1, 1'b1, 1'b0, "stays above");
+
+        // The declared contract is rising-only: the falling crossing is
+        // silent, and the next rising crossing fires again.
+        sample_and_expect(8'h40, 1'b1, 1'b0, 1'b0, "falling crossing silent");
+        sample_and_expect(8'hb0, 1'b1, 1'b1, 1'b1, "second rising crossing");
+
+        // Unqualified cycles change nothing even with crossing-shaped data.
+        sample_and_expect(8'h10, 1'b0, 1'b1, 1'b0, "invalid low ignored");
+        sample_and_expect(8'hf0, 1'b0, 1'b1, 1'b0, "invalid high ignored");
+
+        // Lowering the level into the band reproduces the level-0x37 bench
+        // experiment: previously silent readings start crossing.
+        @(negedge clk);
+        trigger_level = 8'h37;
+        sample_and_expect(8'h20, 1'b1, 1'b0, 1'b0, "below moved level");
+        sample_and_expect(8'h52, 1'b1, 1'b1, 1'b1, "noise crosses moved level");
+
+        // Disarm clears comparison history; re-arm needs a fresh seed.
+        @(negedge clk);
+        arm_enable = 1'b0;
+        sample_and_expect(8'hf0, 1'b1, 1'b0, 1'b0, "disarm clears state");
+        @(negedge clk);
+        arm_enable = 1'b1;
+        sample_and_expect(8'hf0, 1'b1, 1'b1, 1'b0, "re-armed seed sample");
+
+        if (failures != 0) begin
+            $fatal(1, "trigger_comparator failed with %0d error(s)", failures);
+        end
+
+        $display("PASS: seed suppression, rising-only events, level moves, qualification, and disarm reset");
+        $finish;
+    end
+
+endmodule

--- a/fpga/sim/tb_trigger_timebase.sv
+++ b/fpga/sim/tb_trigger_timebase.sv
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+`timescale 1ns/1ps
+
+module tb_trigger_timebase;
+
+    localparam int unsigned COUNTER_WIDTH = 4;
+
+    logic                     clk;
+    logic                     reset_n;
+    logic                     raw_arm_enable;
+    logic [COUNTER_WIDTH-1:0] raw_interval_minus_one;
+    logic                     raw_trigger_event;
+    logic                     sample_tick;
+    logic                     trigger_pulse;
+    logic                     trigger_seen;
+
+    int unsigned failures;
+
+    always #5 clk = ~clk;
+
+    trigger_timebase #(
+        .COUNTER_WIDTH(COUNTER_WIDTH)
+    ) dut (
+        .clk(clk),
+        .reset_n(reset_n),
+        .raw_arm_enable(raw_arm_enable),
+        .raw_interval_minus_one(raw_interval_minus_one),
+        .raw_trigger_event(raw_trigger_event),
+        .sample_tick(sample_tick),
+        .trigger_pulse(trigger_pulse),
+        .trigger_seen(trigger_seen)
+    );
+
+    task automatic clock_and_expect(
+        input logic expected_tick,
+        input logic expected_pulse,
+        input logic expected_seen,
+        input string label
+    );
+        begin
+            @(posedge clk);
+            #1;
+
+            if (sample_tick !== expected_tick) begin
+                $error("%s: sample_tick got %b, expected %b",
+                       label, sample_tick, expected_tick);
+                failures++;
+            end
+            if (trigger_pulse !== expected_pulse) begin
+                $error("%s: trigger_pulse got %b, expected %b",
+                       label, trigger_pulse, expected_pulse);
+                failures++;
+            end
+            if (trigger_seen !== expected_seen) begin
+                $error("%s: trigger_seen got %b, expected %b",
+                       label, trigger_seen, expected_seen);
+                failures++;
+            end
+        end
+    endtask
+
+    initial begin
+        clk = 1'b0;
+        reset_n = 1'b0;
+        raw_arm_enable = 1'b0;
+        raw_interval_minus_one = COUNTER_WIDTH'(2);
+        raw_trigger_event = 1'b0;
+        failures = 0;
+
+        repeat (2) @(posedge clk);
+        #1;
+        reset_n = 1'b1;
+
+        // Negative control: neither timebase nor trigger progresses disarmed.
+        raw_trigger_event = 1'b1;
+        clock_and_expect(1'b0, 1'b0, 1'b0, "disarmed raw event");
+        raw_trigger_event = 1'b0;
+        clock_and_expect(1'b0, 1'b0, 1'b0, "disarmed idle");
+
+        // raw_interval_minus_one=2 means one tick every three armed clocks.
+        @(negedge clk);
+        raw_arm_enable = 1'b1;
+        clock_and_expect(1'b0, 1'b0, 1'b0, "interval cycle 1");
+        clock_and_expect(1'b0, 1'b0, 1'b0, "interval cycle 2");
+        clock_and_expect(1'b1, 1'b0, 1'b0, "interval cycle 3");
+        clock_and_expect(1'b0, 1'b0, 1'b0, "next interval cycle 1");
+
+        // The first event pulses and latches; later events remain ignored.
+        @(negedge clk);
+        raw_trigger_event = 1'b1;
+        clock_and_expect(1'b0, 1'b1, 1'b1, "first trigger event");
+        clock_and_expect(1'b1, 1'b0, 1'b1, "held trigger event");
+        @(negedge clk);
+        raw_trigger_event = 1'b0;
+        clock_and_expect(1'b0, 1'b0, 1'b1, "trigger latch persists");
+
+        // Disarm clears the phase and trigger latch. Re-arm restarts from the
+        // first interval cycle rather than leaking the old counter state.
+        @(negedge clk);
+        raw_arm_enable = 1'b0;
+        clock_and_expect(1'b0, 1'b0, 1'b0, "disarm clears state");
+        @(negedge clk);
+        raw_arm_enable = 1'b1;
+        clock_and_expect(1'b0, 1'b0, 1'b0, "re-arm cycle 1");
+        clock_and_expect(1'b0, 1'b0, 1'b0, "re-arm cycle 2");
+        clock_and_expect(1'b1, 1'b0, 1'b0, "re-arm cycle 3");
+
+        // Zero is explicitly defined as one tick per active clock.
+        @(negedge clk);
+        raw_arm_enable = 1'b0;
+        raw_interval_minus_one = '0;
+        clock_and_expect(1'b0, 1'b0, 1'b0, "zero interval while disarmed");
+        @(negedge clk);
+        raw_arm_enable = 1'b1;
+        clock_and_expect(1'b1, 1'b0, 1'b0, "zero interval cycle 1");
+        clock_and_expect(1'b1, 1'b0, 1'b0, "zero interval cycle 2");
+
+        if (failures != 0) begin
+            $fatal(1, "trigger_timebase failed with %0d error(s)", failures);
+        end
+
+        $display("PASS: periodic tick, first trigger latch, disarm reset, and disabled negative control");
+        $finish;
+    end
+
+endmodule

--- a/fpga/tests/test_capture_bsram_mapping.py
+++ b/fpga/tests/test_capture_bsram_mapping.py
@@ -18,7 +18,10 @@ class CaptureBsramMappingTest(unittest.TestCase):
         sources = [
             RTL / "capture_channel.sv",
             RTL / "trigger_timebase.sv",
+            RTL / "trigger_comparator.sv",
             RTL / "spi_runtime_interface.sv",
+            RTL / "spi_control_registers.sv",
+            RTL / "rate_divider.sv",
             RTL / "fnirsi_2c53t_top.sv",
         ]
         script = " ; ".join([

--- a/fpga/tests/test_capture_bsram_mapping.py
+++ b/fpga/tests/test_capture_bsram_mapping.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Reject a GW1N default capture build if BSRAM mapping regresses."""
+
+import pathlib
+import re
+import shutil
+import subprocess
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+RTL = ROOT / "fpga" / "rtl"
+
+
+@unittest.skipUnless(shutil.which("yosys"), "yosys is required for BSRAM mapping check")
+class CaptureBsramMappingTest(unittest.TestCase):
+    def test_default_top_uses_two_bsrams(self):
+        sources = [
+            RTL / "capture_channel.sv",
+            RTL / "trigger_timebase.sv",
+            RTL / "spi_runtime_interface.sv",
+            RTL / "fnirsi_2c53t_top.sv",
+        ]
+        script = " ; ".join([
+            "read_verilog -sv " + " ".join(map(str, sources)),
+            "synth_gowin -family gw1n -top fnirsi_2c53t_top",
+            "stat",
+        ])
+        result = subprocess.run(
+            ["yosys", "-Q", "-p", script],
+            cwd=ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertNotIn("Replacing memory", result.stdout)
+
+        cells = {
+            name: int(count)
+            for count, name in re.findall(r"^\s*(\d+)\s+(DPX9B|DFFE|LUT4)\s*$", result.stdout, re.MULTILINE)
+        }
+        self.assertEqual(cells.get("DPX9B"), 2, result.stdout)
+        self.assertLess(cells.get("DFFE", 0), 100, result.stdout)
+        self.assertLess(cells.get("LUT4", 0), 1000, result.stdout)
+
+    def test_top_default_capture_depth_is_1024(self):
+        top_source = (RTL / "fnirsi_2c53t_top.sv").read_text()
+        self.assertRegex(
+            top_source,
+            r"parameter\s+int\s+unsigned\s+CAPTURE_DEPTH\s*=\s*1024\s*,",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/fpga/tests/test_netlist_verification.py
+++ b/fpga/tests/test_netlist_verification.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOLS = ROOT / "tools"
+sys.path.insert(0, str(TOOLS))
+
+from canonicalize_yosys_json import canonicalize, primitive_inventory  # noqa: E402
+
+VERIFY = TOOLS / "verify_structural_netlists.py"
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class CanonicalizeTests(unittest.TestCase):
+    def test_bit_ids_and_source_attributes_do_not_affect_canonical_form(self) -> None:
+        module_template = {
+            "ports": {
+                "a": {"direction": "input", "bits": [1]},
+                "y": {"direction": "output", "bits": [2]},
+            },
+            "cells": {
+                "u0": {
+                    "type": "LUT4",
+                    "parameters": {"INIT": "0000000000000010"},
+                    "attributes": {"src": "ignored.v:1.1-2.1"},
+                    "port_directions": {"I0": "input", "F": "output"},
+                    "connections": {"I0": [1], "F": [2]},
+                }
+            },
+            "netnames": {"a": {"bits": [1]}, "y": {"bits": [2]}},
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            first = Path(tmp) / "first.json"
+            second = Path(tmp) / "second.json"
+            first.write_text(json.dumps({"modules": {"top": module_template}}))
+            changed = json.loads(json.dumps(module_template))
+            changed["ports"]["a"]["bits"] = [41]
+            changed["ports"]["y"]["bits"] = [99]
+            changed["cells"]["u0"]["connections"] = {"I0": [41], "F": [99]}
+            changed["cells"]["u0"]["attributes"]["src"] = "elsewhere.v:8.1-9.1"
+            changed["netnames"]["a"]["bits"] = [41]
+            changed["netnames"]["y"]["bits"] = [99]
+            second.write_text(json.dumps({"modules": {"top": changed}}))
+            canonical = canonicalize(first)
+            self.assertEqual(canonical, canonicalize(second))
+            self.assertEqual({"LUT4": 1}, primitive_inventory(canonical))
+
+
+class VerifierIntegrationTests(unittest.TestCase):
+    def run_verifier(self, archived: Path, fresh: Path, **overrides: str) -> subprocess.CompletedProcess[str]:
+        command = [
+            sys.executable,
+            str(VERIFY),
+            "--archived",
+            str(archived),
+            "--archived-sha256",
+            overrides.get("archived_sha256", sha256(archived)),
+            "--fresh",
+            str(fresh),
+            "--fresh-sha256",
+            overrides.get("fresh_sha256", sha256(fresh)),
+        ]
+        return subprocess.run(command, text=True, capture_output=True, check=False)
+
+    def test_matching_structure_passes_and_reports_inventory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archived = Path(tmp) / "archived.v"
+            fresh = Path(tmp) / "fresh.v"
+            archived.write_text(
+                "module top(input a, output y); wire n; LUT4 #(.INIT(16'h0002)) u0 (.I0(a), .F(n)); assign y=n; endmodule\n"
+            )
+            fresh.write_text(
+                "module top(output y, input a); wire n; LUT4 #(.INIT(16'h0002)) u0 (.F(n), .I0(a)); assign y = n; endmodule\n"
+            )
+            result = self.run_verifier(archived, fresh)
+            self.assertEqual(0, result.returncode, result.stderr)
+            report = json.loads(result.stdout)
+            self.assertTrue(report["structural_match"])
+            self.assertEqual({"LUT4": 1}, report["primitive_inventory"]["archived"])
+            self.assertIn("not behavioral", report["scope"])
+
+    def test_changed_primitive_fails_structural_comparison(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archived = Path(tmp) / "archived.v"
+            fresh = Path(tmp) / "fresh.v"
+            archived.write_text("module top(input a, output y); LUT4 u0 (.I0(a), .F(y)); endmodule\n")
+            fresh.write_text("module top(input a, output y); DFF u0 (.D(a), .Q(y)); endmodule\n")
+            result = self.run_verifier(archived, fresh)
+            self.assertEqual(1, result.returncode, result.stderr)
+            report = json.loads(result.stdout)
+            self.assertFalse(report["structural_match"])
+            self.assertEqual({"LUT4": 1}, report["primitive_inventory"]["archived"])
+            self.assertEqual({"DFF": 1}, report["primitive_inventory"]["fresh"])
+
+    def test_wrong_input_hash_stops_with_precondition_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            archived = Path(tmp) / "archived.v"
+            fresh = Path(tmp) / "fresh.v"
+            archived.write_text("module top(input a, output y); assign y=a; endmodule\n")
+            fresh.write_text(archived.read_text())
+            result = self.run_verifier(archived, fresh, archived_sha256="0" * 64)
+            self.assertEqual(2, result.returncode)
+            report = json.loads(result.stderr)
+            self.assertIn("archived SHA-256 mismatch", report["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/fpga/tools/build_debugclk_image.sh
+++ b/fpga/tools/build_debugclk_image.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Build the debug-clock hardware validation image for the exact GW1N-UV2/QN48
+# part.  Produces an SRAM-load-only .fs bitstream in a build directory outside
+# the repository; build products are deliberately not committed.  Nothing here
+# authorizes writing the FPGA's non-volatile flash.
+#
+# Host-provided prerequisites (tool provenance in fpga/docs/provenance.md):
+#   APICULA_PYTHON  python with apycula installed from the apicula branch
+#                   carrying the GW1N-UV2 QN48 pinout and speed-keyed package
+#                   (agent/gw1n2-qn48-chipdb-20260815) plus a built
+#                   apycula/GW1N-2.msgpack.xz chip database
+#   NEXTPNR         nextpnr-himbaechel binary built from the gw1n2 branch
+#   NEXTPNR_SRC     that nextpnr source tree (for gowin_arch_gen.py)
+#   BBASM           the bba assembler from the same nextpnr build
+set -eu
+
+REPO=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+OUT=${OUT:-"${TMPDIR:-/tmp}/openscope-debugclk-build"}
+mkdir -p "$OUT"
+
+RTL="$REPO/fpga/rtl/capture_channel.sv
+$REPO/fpga/rtl/trigger_timebase.sv
+$REPO/fpga/rtl/trigger_comparator.sv
+$REPO/fpga/rtl/spi_runtime_interface.sv
+$REPO/fpga/rtl/spi_control_registers.sv
+$REPO/fpga/rtl/rate_divider.sv
+$REPO/fpga/rtl/fnirsi_2c53t_top.sv
+$REPO/fpga/rtl/debugclk_hw_top.sv"
+
+yosys -Q -p "read_verilog -sv $(printf '%s ' $RTL); \
+    synth_gowin -family gw1n -top debugclk_hw_top -json $OUT/debugclk_hw_top.json"
+
+"$APICULA_PYTHON" "$NEXTPNR_SRC/himbaechel/uarch/gowin/gowin_arch_gen.py" \
+    -d GW1N-2 -o "$OUT/chipdb-GW1N-2.bba"
+"$BBASM" --l "$OUT/chipdb-GW1N-2.bba" "$OUT/chipdb-GW1N-2.bin"
+
+# The fully qualified ordering code is required: the nextpnr gowin uarch
+# splits the speed grade off the device string, and gowin_pack looks the full
+# code up in the chip database.  disable_gp_clock_routing keeps the CS/SCLK
+# nets off the dedicated clock network, which cannot reach their sinks from
+# these pads; at MCU debug-clock rates fabric routing has orders-of-magnitude
+# timing margin (reported >90 MHz).
+"$NEXTPNR" --json "$OUT/debugclk_hw_top.json" \
+    --write "$OUT/debugclk_hw_top_routed.json" \
+    --device 'GW1N-UV2QN48XFC6/I5' \
+    --chipdb "$OUT/chipdb-GW1N-2.bin" \
+    --vopt family=GW1N-2 \
+    --vopt disable_gp_clock_routing \
+    --vopt cst="$REPO/fpga/constraints/fnirsi_2c53t_qn48.cst"
+
+"$(dirname -- "$APICULA_PYTHON")/gowin_pack" -d GW1N-2 \
+    -o "$OUT/debugclk_hw_top.fs" "$OUT/debugclk_hw_top_routed.json"
+
+sha256sum "$OUT/debugclk_hw_top.fs"
+echo "SRAM-only image ready: $OUT/debugclk_hw_top.fs"

--- a/fpga/tools/canonicalize_yosys_json.py
+++ b/fpga/tools/canonicalize_yosys_json.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Canonicalize a one-module Yosys JSON netlist by named connectivity.
+
+Yosys assigns integer bit IDs in parse order. Apicula emits declarations and
+instances from sets, so two structurally matching unpack runs can receive
+different IDs. This tool replaces each integer bit with the complete, sorted
+set of named aliases attached to that bit and sorts dictionaries before
+serialization. Source-path attributes are deliberately excluded.
+
+This is a structural comparison aid. A match does not establish behavioral,
+timing, placement, routing, or bitstream equivalence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+def canonicalize(path: Path, *, top: str = "top") -> dict[str, Any]:
+    data = json.loads(path.read_text())
+    if set(data["modules"]) != {top}:
+        modules = ", ".join(sorted(data["modules"]))
+        raise ValueError(f"expected only module {top!r} in {path}; found: {modules}")
+    module = data["modules"][top]
+
+    aliases: dict[int, list[str]] = defaultdict(list)
+    for name, net in module["netnames"].items():
+        for index, bit in enumerate(net["bits"]):
+            if isinstance(bit, int):
+                aliases[bit].append(f"{name}[{index}]")
+
+    def bit_name(bit: int | str) -> str | tuple[str, ...]:
+        if isinstance(bit, str):
+            return bit
+        names = aliases.get(bit)
+        if not names:
+            return (f"$unnamed:{bit}",)
+        return tuple(sorted(names))
+
+    ports = {
+        name: {
+            "direction": port["direction"],
+            "bits": [bit_name(bit) for bit in port["bits"]],
+        }
+        for name, port in sorted(module["ports"].items())
+    }
+
+    cells = {}
+    for name, cell in sorted(module["cells"].items()):
+        cells[name] = {
+            "type": cell["type"],
+            "parameters": dict(sorted(cell.get("parameters", {}).items())),
+            "port_directions": dict(sorted(cell.get("port_directions", {}).items())),
+            "connections": {
+                port: [bit_name(bit) for bit in bits]
+                for port, bits in sorted(cell["connections"].items())
+            },
+        }
+
+    alias_groups = sorted(tuple(sorted(names)) for names in aliases.values() if names)
+    return {"ports": ports, "cells": cells, "alias_groups": alias_groups}
+
+
+def primitive_inventory(canonical: dict[str, Any]) -> dict[str, int]:
+    """Return a stable cell-type inventory from canonicalized structure."""
+    counts = Counter(cell["type"] for cell in canonical["cells"].values())
+    return dict(sorted(counts.items()))
+
+
+def write_canonical_json(result: dict[str, Any], output: Path) -> None:
+    output.write_text(json.dumps(result, sort_keys=True, separators=(",", ":")) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="one-module Yosys JSON input")
+    parser.add_argument("output", type=Path, help="canonical JSON output")
+    parser.add_argument("--top", default="top", help="expected sole module (default: top)")
+    args = parser.parse_args()
+
+    try:
+        result = canonicalize(args.input, top=args.top)
+    except (KeyError, json.JSONDecodeError, ValueError) as error:
+        parser.error(str(error))
+    write_canonical_json(result, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/fpga/tools/verify_structural_netlists.py
+++ b/fpga/tools/verify_structural_netlists.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Compare archived and fresh unpacked Verilog netlists structurally.
+
+Both input SHA-256 values are mandatory. The verifier asks Yosys to parse each
+input into JSON, canonicalizes named connectivity, reports primitive inventory,
+and compares the canonical documents. Generated JSON is kept in a temporary
+directory and is never written into the repository.
+
+A passing result establishes only equality under this structural oracle. It
+does not establish behavioral, timing, placement, routing, or bitstream
+equivalence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from canonicalize_yosys_json import canonicalize, primitive_inventory
+
+SHA256_RE = re.compile(r"[0-9a-fA-F]{64}\Z")
+SCOPE = (
+    "named structural connectivity only; not behavioral, timing, placement, "
+    "routing, or bitstream equivalence"
+)
+
+
+class VerificationError(Exception):
+    """An input or tool precondition prevented structural comparison."""
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def checked_hash(path: Path, expected: str, label: str) -> str:
+    if not SHA256_RE.fullmatch(expected):
+        raise VerificationError(f"{label} expected SHA-256 must be 64 hex digits")
+    if not path.is_file():
+        raise VerificationError(f"{label} input is not a file: {path}")
+    actual = sha256_file(path)
+    if actual != expected.lower():
+        raise VerificationError(
+            f"{label} SHA-256 mismatch: expected {expected.lower()}, got {actual}"
+        )
+    return actual
+
+
+def yosys_json(input_path: Path, output_path: Path, *, yosys: str, top: str) -> None:
+    input_link = output_path.with_suffix(".v")
+    input_link.symlink_to(input_path.resolve())
+    # Unpacked gate-level netlists intentionally instantiate Gowin primitives
+    # without defining those vendor modules. Do not use ``hierarchy -check``:
+    # the unresolved cells are exactly the structures this verifier inventories.
+    script = f"read_verilog {input_link.name}; hierarchy -top {top}; write_json {output_path.name}"
+    completed = subprocess.run(
+        [yosys, "-q", "-p", script],
+        cwd=output_path.parent,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "no diagnostic"
+        raise VerificationError(
+            f"Yosys failed for {input_path} with exit {completed.returncode}: {detail}"
+        )
+
+
+def canonical_digest(document: dict[str, Any]) -> str:
+    payload = json.dumps(document, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def verify(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    archived_hash = checked_hash(args.archived, args.archived_sha256, "archived")
+    fresh_hash = checked_hash(args.fresh, args.fresh_sha256, "fresh")
+
+    with tempfile.TemporaryDirectory(prefix="netlist-structural-check-") as tmp:
+        work = Path(tmp)
+        archived_json = work / "archived.json"
+        fresh_json = work / "fresh.json"
+        yosys_json(args.archived, archived_json, yosys=args.yosys, top=args.top)
+        yosys_json(args.fresh, fresh_json, yosys=args.yosys, top=args.top)
+        try:
+            archived = canonicalize(archived_json, top=args.top)
+            fresh = canonicalize(fresh_json, top=args.top)
+        except (KeyError, json.JSONDecodeError, ValueError) as error:
+            raise VerificationError(str(error)) from error
+
+    match = archived == fresh
+    report = {
+        "oracle": "yosys_named_structural_connectivity",
+        "scope": SCOPE,
+        "structural_match": match,
+        "inputs": {
+            "archived": {"path": str(args.archived), "sha256": archived_hash},
+            "fresh": {"path": str(args.fresh), "sha256": fresh_hash},
+        },
+        "canonical_sha256": {
+            "archived": canonical_digest(archived),
+            "fresh": canonical_digest(fresh),
+        },
+        "primitive_inventory": {
+            "archived": primitive_inventory(archived),
+            "fresh": primitive_inventory(fresh),
+        },
+    }
+    return (0 if match else 1), report
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archived", required=True, type=Path)
+    parser.add_argument("--archived-sha256", required=True)
+    parser.add_argument("--fresh", required=True, type=Path)
+    parser.add_argument("--fresh-sha256", required=True)
+    parser.add_argument("--yosys", default="yosys")
+    parser.add_argument("--top", default="top")
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        status, report = verify(args)
+    except (OSError, VerificationError) as error:
+        print(json.dumps({"error": str(error), "scope": SCOPE}, sort_keys=True), file=sys.stderr)
+        raise SystemExit(2) from error
+    print(json.dumps(report, indent=2, sort_keys=True))
+    raise SystemExit(status)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
> [!WARNING]
> This is an intermediate reconstruction draft. It is **not ready to merge** and has not been validated on hardware.

## What this draft contains

- Editable, modular SystemVerilog for the GW1N-2/GW1N-UV2 FPGA: capture buffers, runtime SPI, trigger/timebase, and an integration top.
- Grounded `0x04`/`0x05` runtime reads with observed 1026-byte CS-low framing; unknown commands and status values stay raw.
- Low-five-bit opcode decode matching the exhaustive alias sweep, a control-register bank committing the observed two-byte write frames, the bench-proven digital post-ADC trigger comparator on register `0x08` (stock arms `0xAD`), and an SPI-loadable rate divider reconstructing the traced `BSRAM_1/2` counter-gate shape with its load select marked as an explicit placeholder.
- A first buildable exact-part validation image (`debugclk_hw_top` + a six-pin QN48 constraint set + `build_debugclk_image.sh`): MCU-driven debug clock on IOB7B (pin 30), IOR1B run line (pin 46), and the four netlist-traced runtime SPI pins, with synthetic ramp / walking-one ADC data through the real capture path. SRAM-load-only, reproducible, no bitstream committed, unproven on hardware.
- Two inferred Gowin `DPX9B` capture memories at the default `1024x8` depth instead of register-expanded RAM.
- Simulations, a BSRAM synthesis regression, and structural-netlist comparison tools.
- Provenance for the stock payload at offset `0x4AD19`, length `115638`, and IDCODE `0x0120681B`.

This is reconstruction work, not recovered original HDL. It builds on [DavidClawson/OpenScope-2C53T#18](https://github.com/DavidClawson/OpenScope-2C53T/issues/18) and [YosysHQ/apicula#515](https://github.com/YosysHQ/apicula/issues/515).

## Checks run on `25eb00b`

- Python: 6 tests passed, including BSRAM/default-depth, changed-primitive, and wrong-input-hash negative controls.
- Icarus Verilog: all eight testbenches passed, including the comparator, control-register, and rate-divider units, the reworked integrated top, and the debug-clock hardware wrapper validated through its six physical nets only.
- Verilator 5.048: whole-RTL lint passed.
- Yosys 0.66 `synth_gowin`: two `DPX9B`, 84 `LUT4`; no memory-to-register warning.
- nextpnr-himbaechel (gw1n2 branch) on `GW1N-UV2QN48XFC6/I5` with the six-pin CST: placed on the exact constrained pads, routed, timing >90 MHz on both clock domains; `gowin_pack` emits a `.fs` carrying IDCODE `0x0120681B`, sha256-stable across independent builds (`9c465d72a5cd5866b7c4b06baa87f10b2e4e3c5f965f09c1518fa08c47d10751`).
- `git diff --check`: passed.

Exact-QN48 toolchain work lives at [Komzpa/apicula `agent/gw1n2-qn48-chipdb-20260815`](https://github.com/Komzpa/apicula/tree/agent/gw1n2-qn48-chipdb-20260815), now at commit `d978cad`. It builds a database containing `GW1N-UV2QN48XF -> QN48/GW1N-2` with the UV1P5 proxy absent, keys the package by its full ordering code so `gowin_pack` resolves it, and maps the top-right corner tile to `IOR1` (the run pin) instead of a nonexistent `IOT20`. With those fixes the debug-clock validation image builds end to end for the exact part.

## Why this remains a draft

- Exact board-net constraints are complete only for the six netlist-traced pins used by the debug-clock image; the ADC bus, PLL clock input, and remaining enable mappings still lack continuity-grade evidence, so the full scope top still cannot be placed.
- The stock rPLL configuration remains undecoded; the buildable image substitutes an MCU-driven debug clock and synthetic ADC data, so it validates the capture/trigger/SPI fabric, not stock sample rates.
- The archived Saleae `.sal` trace is hash-pinned, but Logic 2/export tooling is unavailable here, so byte-for-byte trace replay is not yet automated.
- The trigger threshold register (`0x08`, in ADC codes) is bench-decoded, but stock source/edge selection, hysteresis, holdoff, pre/post-trigger policy, buffer ordering, CDC behavior, the rate-divisor register address, and status-byte semantics remain unknown.
- No formal or behavioral equivalence to the stock design is claimed.
- No FPGA image from this branch has been loaded onto hardware.

The branch contains no generated bitstream and does not authorize non-volatile FPGA programming.

