### PR TITLE
fpga: build the EXP-37 edge-capture rig only where its bit-bang half exists

### DIFF
--- a/firmware/src/drivers/fpga.c
+++ b/firmware/src/drivers/fpga.c
@@ -390,6 +390,22 @@ static uint8_t spi3_xfer(uint8_t tx_byte)
     return (uint8_t)FPGA_SPI->dt;
 }
 
+/* [H-gapless / post-H6 suspect (a)] Clock each mode-0 prelude frame's two bytes
+ * GAPLESSLY via spi3_xfer2_gapless() instead of the stalling spi3_xfer(), so SCK
+ * does not idle between the command byte and its 0x00 param inside the CS-LOW
+ * frame — matching the continuous clocking of both working transports (bit-bang
+ * + stock). This is the LAST untested firmware axis after H1-H6: register/byte/
+ * framing are all excluded, so the only firmware-reachable difference left is the
+ * intra-frame cadence our polled peripheral introduces. 0 = shipping path
+ * (spi3_xfer, stalling). Test: `make guest-configA-gapless`. Mode-0 only.
+ *
+ * The default lives here, above spi3_xfer2_gapless(), so the helper can be
+ * compiled only for the builds that call it. */
+#ifndef FPGA_HW_PRELUDE_GAPLESS
+#define FPGA_HW_PRELUDE_GAPLESS 0
+#endif
+
+#if FPGA_HW_PRELUDE_GAPLESS
 /* [H-gapless] Send two bytes back-to-back with NO inter-byte stall — the
  * double-buffered idiom of spi3_pump_h2_record(), for a 2-byte prelude frame.
  *
@@ -427,6 +443,7 @@ static void spi3_xfer2_gapless(uint8_t b0, uint8_t b1, uint8_t *r0, uint8_t *r1)
     if (r0) *r0 = rx0;
     if (r1) *r1 = rx1;
 }
+#endif /* FPGA_HW_PRELUDE_GAPLESS */
 
 static void fpga_h2_record_body_rx(uint8_t rx_byte)
 {
@@ -477,18 +494,6 @@ static void fpga_h2_record_close_rx(uint8_t rx_byte)
  * See docs/config_entry_hw_spi_hypotheses.md (H2 — the converged lead). */
 #ifndef FPGA_HW_CS_DUMMY
 #define FPGA_HW_CS_DUMMY 0
-#endif
-
-/* [H-gapless / post-H6 suspect (a)] Clock each mode-0 prelude frame's two bytes
- * GAPLESSLY via spi3_xfer2_gapless() instead of the stalling spi3_xfer(), so SCK
- * does not idle between the command byte and its 0x00 param inside the CS-LOW
- * frame — matching the continuous clocking of both working transports (bit-bang
- * + stock). This is the LAST untested firmware axis after H1-H6: register/byte/
- * framing are all excluded, so the only firmware-reachable difference left is the
- * intra-frame cadence our polled peripheral introduces. 0 = shipping path
- * (spi3_xfer, stalling). Test: `make guest-configA-gapless`. Mode-0 only. */
-#ifndef FPGA_HW_PRELUDE_GAPLESS
-#define FPGA_HW_PRELUDE_GAPLESS 0
 #endif
 
 /* Double-buffered SPI3 pump for the H2 upload (per GitHub issue #11, Lanchon).
@@ -5788,7 +5793,11 @@ void fpga_spi3_bus_reacquire(void)
  * NOTE: this fires ISOLATED 0x15 frames — no 05/12 prelude — so it does NOT
  * configure anything; it exists purely to photograph the SCK/MOSI/CS waveform of
  * a 0x15 frame under each drive. `reps` frames per group, ~2ms apart; 60ms gap
- * between the AF and GPIO bursts as a marker. */
+ * between the AF and GPIO bursts as a marker.
+ *
+ * Bit-bang half only exists under FPGA_CONFIG_B (BB_* pin masks, bb_cmd16), so
+ * the rig is built only for those images — `make guest-bringup-bb`. */
+#if FPGA_CONFIG_B
 void fpga_edgecap_15(uint8_t reps)
 {
     gpio_init_type gpio_cfg;
@@ -5834,6 +5843,7 @@ void fpga_edgecap_15(uint8_t reps)
     /* Restore AF bus so later shell commands work. */
     fpga_spi3_bus_reacquire();
 }
+#endif /* FPGA_CONFIG_B */
 
 void fpga_scope_reinit(void)
 {

--- a/firmware/src/drivers/fpga.h
+++ b/firmware/src/drivers/fpga.h
@@ -771,8 +771,11 @@ void fpga_spi3_bus_reacquire(void);
 /* EXP-37: LA edge-capture. Emits `reps` (0 => 16) identical 0x15 CONFIG_ENABLE
  * frames over AF hardware-SPI3 (/256), a 60ms gap, then `reps` over GPIO bit-bang
  * — same pins/rate/frame, drive type the only variable. Isolated frames; does NOT
- * configure. Arm sigrok (D0=SCK/D1=MISO/D2=MOSI/D3=CS) before calling. */
+ * configure. Arm sigrok (D0=SCK/D1=MISO/D2=MOSI/D3=CS) before calling.
+ * FPGA_CONFIG_B builds only — the bit-bang half is compiled out elsewhere. */
+#if FPGA_CONFIG_B
 void fpga_edgecap_15(uint8_t reps);
+#endif
 
 /*
  * Cooperative acquisition pause (Step 0b, bench plan 2026-08-14).

--- a/firmware/src/drivers/usb_debug.c
+++ b/firmware/src/drivers/usb_debug.c
@@ -5877,9 +5877,18 @@ static void cmd_spi3_gowin(void)
  * CONFIG_ENABLE frames over AF hardware-SPI3 (/256), a 60ms gap, then [reps] over
  * GPIO bit-bang — same pins/rate/frame, drive type the only variable. Isolated
  * frames; does NOT configure. Arm sigrok (D0=SCK/D1=MISO/D2=MOSI/D3=CS) BEFORE
- * running, then diff the two bursts. */
+ * running, then diff the two bursts.
+ *
+ * The rig needs the bit-bang transport, which only exists under FPGA_CONFIG_B.
+ * The command stays in the table on every build and says so, rather than
+ * disappearing from `help` and leaving the operator guessing. */
 static void cmd_spi3_edgecap(const char *args)
 {
+#if !FPGA_CONFIG_B
+    (void)args;
+    usb_send_str("edgecap: FPGA_CONFIG_B builds only — the GPIO bit-bang half is not"
+                 " compiled here. Flash `make guest-bringup-bb`.\r\n");
+#else
     uint32_t reps = 16;
     if (args && *args) reps = (uint32_t)strtoul(args, NULL, 0);
     if (reps == 0 || reps > 255) reps = 16;
@@ -5888,6 +5897,7 @@ static void cmd_spi3_edgecap(const char *args)
     usb_send_str("  emitting now — capture window should be armed on D0=SCK D1=MISO D2=MOSI D3=CS\r\n");
     fpga_edgecap_15((uint8_t)reps);
     usb_send_str("edgecap: done. AF burst | gap | GPIO burst are in the capture.\r\n");
+#endif
 }
 
 /* ─── fpga selftest ────────────────────────────────────────────────────────


### PR DESCRIPTION
`make guest`, `make` (app) and `make emu` do not compile on `main` at `0b7f9d0`. **Measured**, clean worktree of `origin/main` with nothing of mine in it, `arm-none-eabi-gcc 14.2.Rel1`:

```
src/drivers/fpga.c:5816:18: error: 'BB_SCK' undeclared (first use in this function)
src/drivers/fpga.c:5816:27: error: 'BB_CS' undeclared (first use in this function)
src/drivers/fpga.c:5817:18: error: 'BB_MOSI' undeclared (first use in this function)
src/drivers/fpga.c:5823:26: error: 'BB_MISO' undeclared (first use in this function)
src/drivers/fpga.c:5830:9:  error: implicit declaration of function 'bb_cmd16'
make: *** [build/fpga.o] Error 1
```

**Code fact:** `fpga_edgecap_15()` (yours, `e803915`) is compiled unconditionally, while `BB_SCK`/`BB_MISO`/`BB_MOSI`/`BB_CS` and `bb_cmd16()` all live under `#if FPGA_CONFIG_B`. `guest-coldtrace` and `guest-bringup-bb` are unaffected — **measured**, both still build at `0b7f9d0` — which is very likely why the bench never saw it, since those are the two flavours we each flash. That last clause is an inference, not something I measured about your bench.

### What this changes

1. `fpga_edgecap_15()` and its prototype get the same `#if FPGA_CONFIG_B` as the transport they use. The rig is an AF-vs-bit-bang comparison, so it can only mean anything on a `FPGA_CONFIG_B` image anyway.
2. The `spi3 edgecap` shell command stays in the table on **every** build and answers with the flavour to flash, rather than disappearing from `help` and leaving the operator to guess why. Judgement call — say the word if you would rather it were absent.
3. `spi3_xfer2_gapless()` is gated on `FPGA_HW_PRELUDE_GAPLESS`, which is what its three call sites already use. Without that it is an unused-function warning in every default build and your own ratchet in `scripts/test_firmware_build.py` fails app, emu and guest on it. This is the item I offered to push on 2026-08-26 in #29 and did not, because it was your file; the hard build error above changed my mind about waiting. The knob's `#ifndef` default moves up a few hundred lines to sit above the helper, so the guard can read it.

`WARNING_BASELINE` is deliberately **untouched**. The two `[emu]` entries it lists (`vMeterAutoselectTask`, `vUsbDebugTask`) look stale while emu fails to build — no build, no warnings collected, and `test_warning_baseline_is_not_stale` then reports them as retired. With emu compiling again both warnings come back, exactly as the baseline says. I pruned them, saw them return, and put them back; worth knowing that the staleness half of the ratchet reads as a false positive whenever a flavour is broken.

### Verified

| claim | evidence |
|---|---|
| `main` at `0b7f9d0` fails app/emu/guest | measured, clean `origin/main` worktree, output above |
| this branch builds all five gate flavours | measured, `scripts/run_tests.py` 13/13 suites, 95 tests, toolchain present |
| bench targets still build | measured: `guest-coldtrace`, `guest-bringup-bb`, `guest-configA-gapless`, zero errors each |
| `spi3 edgecap` still works where it matters | **not measured on hardware** — it is compiled into `guest-bringup-bb` as before, but I have not re-run the rig with a logic analyser on this build |

No behaviour change is intended for any image: everything moved is either bench-only code or a preprocessor guard matching an existing call-site guard. If you would rather fix this differently in your own file, close this and I will follow whatever lands.