### PR TITLE
meter: the SoC listens to AA 55 — turn the header on and send it the words it obeys

### DIFF
--- a/docs/experiments/2026-09-13-205-word-table-and-header-on-unit2.md
+++ b/docs/experiments/2026-09-13-205-word-table-and-header-on-unit2.md
@@ -1,0 +1,210 @@
+# EXP-205 — The corrected word table under AA 55, on unit #2
+
+- **Date:** 2026-09-13
+- **Unit:** bench unit #2 (Stlkv)
+- **Build:** `make guest-coldtrace-meter`, branch `meter-word-table` (this PR), staged into
+  slot B over the port firmware's CDC loader and installed with `fwswap b`
+- **Status:** **CONFIRMED** — with two defects found and fixed on the way, both in this branch
+
+## 1. Problem
+
+PR (1) of issue #15 turns the meter TX header on by default and replaces the word table.
+Nothing on the bench had ever exercised a *UI-driven* transition with the header live:
+EXP-25/26/27 commanded the SoC by hand (`usart tx`) after entering meter mode. Does
+`mode meter <submode>` select the function it names, does the unobeyed keepalive stay
+silent, and does every one of the eleven words get accepted?
+
+## 2. Hypothesis
+
+With the header on and the measured table in place, each `mode meter N` produces exactly
+one accepted echo and the SoC's frame changes to the signature of function N; the 4 Hz
+keepalive produces no echoes and no relay actuation.
+
+- **If true:** `echo_valid` +1 per transition, `echo_bad` 0, no echo growth between
+  transitions, data frames ~6/s, frame signature per function.
+- **If false:** the echo does not move on a transition, or moves without one.
+
+## 3. Procedure
+
+```
+meter hdr                # default must read AA 55
+mode meter [N] 0         # UI transition path (fpga_set_meter_mode -> fpga_apply_meter_transition)
+meter hdr / status       # echo ladder, tx_frames_recent, transition counters
+meter dump               # frame, nibbles, raw_digits
+meter hdr off            # negative control
+```
+
+Frames are hand-decoded from `nibbles=` (pre-lookup): bit 4 of a digit's nibble is the
+seven-segment decimal point, lit on the digit it precedes; the glyph is the other seven bits.
+
+**Preconditions verified by readback:**
+
+| what | expected | measured |
+|---|---|---|
+| header default | `AA 55 (default)` | ✅ |
+| scope mode, 10 s | TX 0, RX 0 on this flavour (`FPGA_USART_SILENT_SCOPE=1`) | TX 0, RX 0 — so the scope-side control is vacuous here, see §6 |
+| keepalive on the wire | `00 00 05 09` | ✅ every frame in `tx_frames_recent` |
+
+## 4. Control
+
+Positive control, recorded first, on the **first** build of this branch (before the fixes
+below): `usart tx 05 0C` by hand in meter mode → `echo_start 0→1, echo_valid 0→1,
+echo_bad 0`, frame changed from the boot-time `E4 2E 63 25 07 00 00` to a DCV frame
+(`f8=0x82`, reading 0.0003 V). The header and the RX echo path work on this build.
+
+Negative control (final build): `meter hdr off`, then `mode meter 6 0` → the selector was
+sent five times under `00 00`, `echo_valid` unchanged, `confirmed=0`, and the SoC's frame
+stayed the boot-time text — the SoC does not obey `00 00`.
+
+## 5. Results
+
+### 5a. Defect 1 — the transition's selector was never accepted (fixed in this branch)
+
+First build, `mode meter`: TX count climbed, keepalive frames flowed, **`echo_valid` stayed
+0**. `mode meter 6 0`: `tx_control_history` shows `AA 55 05 0B` leaving at tx=401 — the
+selector was transmitted — and the transition history shows `data=558..558`: **not one
+data frame arrived during the transition.** The frame afterwards was the boot-time
+`E4 2E 63 25 07 00 00` (the SoC's power-on "Auto" text), not the DCV frame the SoC had been
+sending a second earlier.
+
+Reading: `fpga_meter_reset_transport()` drops PC11, and the SoC **restarts** — every
+transition lands it back in its power-on state, and it is deaf while it boots. The selector
+20 ms later goes into that silence. The same word typed by hand a second later was echoed
+at once.
+
+Fix: `fpga_meter_wait_for_soc()` waits for the first data frame after PC11 comes back (up
+to 3 s, feeding unobeyed keepalive traffic every 250 ms), then +200 ms; the selector is
+sent by `fpga_send_selector_confirmed()`, which re-sends until its echo arrives (≤5 tries,
+300 ms each). Both are exported by `meter hdr` as `transition: wake_ms= tries= ok=`.
+
+**Measured wake time: 1380 ms, on every one of 24 successful transitions**, boot→meter,
+scope→meter and meter→meter alike. It is a constant, not a distribution.
+
+### 5b. Defect 2 — one scope→meter entry in three had a dead transceiver (fixed)
+
+With the wait in place, 2 of 6 and then 1 of 4 scope→meter entries still timed out with no
+frame at all (`wake_ms=65535`, five unanswered tries). In that state:
+
+| readback | failed entry | good entry |
+|---|---|---|
+| `USART2 CTRL1` | `0x20A0` — UEN=1, **TE=0, RE=0** | `0x202C` — TE=1, RE=1 |
+| TX count | climbing (into a disabled transmitter) | climbing |
+| RX bytes | frozen | climbing |
+| `usart tx 05 0C` by hand | no echo | echo |
+
+Mechanism (code reading, consistent with every observation): on a silent-scope build,
+scope entry parks USART2 with `ctrl1 = 0`. The transition's `reset_transport()` reads
+`ctrl1`, quiets the bus for 20 ms, then restores `ctrl1 | UEN | RDBFIEN`. The display task's
+`fpga_set_meter_mux(true)` re-arms USART2 asynchronously when it notices the mode change;
+when that lands inside the 20 ms window, the restore overwrites it with TE/RE clear. Fix:
+the restore now sets TE and RE and enables the USART2 IRQ unconditionally — the transition
+is about to talk to the SoC, so it owns the transceiver.
+
+After the fix: **8/8 scope→meter entries confirmed on the first try, `CTRL1=0x202C` every
+time, `wake_timeouts=0`, `unconfirmed=0`.**
+
+### 5c. All eleven words accepted; frame signatures on open probes
+
+| submode | word | echo Δ | tries | wake_ms | frame[2..11] | signature |
+|---|---|---|---|---|---|---|
+| 0 DCV | `050C` | +1 | 1 | 1380 | `F6 EB EB CB 07 00 82 00 00 FC` | f8=0x82, 0.0005 V |
+| 1 ACV | `050D` | +1 | 1 | 1380 | `E5 EB EB EB 0B 00 82 00 00 00` | f8=0x82, "0000" |
+| 2 DC mA | `0511` | +1 | 1 | 1380 | `F6 FB EB 8B 0F 01 01 00 01 0D` | f8 bit0, -00.03 mA |
+| 3 DC A | `0510` | +1 | 1 | 1380 | `F6 EB EB AB 0D 00 81 00 01 0F` | f8=0x81, 0.002 A |
+| 4 AC mA | `0516` | +1 | 1 | 1380 | `E5 FB EB EB 0F 01 01 00 00 00` | f8 bit0 |
+| 5 AC A | `0515` | +1 | 1 | 1380 | `E5 EB EB 8B 0A 00 81 00 00 00` | f8=0x81 |
+| 6 Ω | `050B` | +1 | 1 | 1380 | `04 F0 6B 01 00 24 00 00 01 0B` | f7=0x24, " 0L " |
+| 7 Cont | `0517` | +1 | 1 | 1380 | `00 E0 7B 01 00 28 00 00 01 15` | f7=0x28, " 0L " |
+| 8 Diode | `050E` | +1 | 1 | 1380 | `00 F0 6B 01 80 00 02 00 01 0B` | f8=0x02, " 0L " |
+| 9 Cap | `050A` | +1 | 1 | 1380 | `E4 FB EB EB 2B 10 00 00 00 FE` | f7=0x10, f6=0x2_ (nF), "000.0" |
+| 10 Temp | `0512` | +1 | 1 | 1380 | `00 00 A0 ED 0F 00 20 00 01 1F` | f8=0x20, "  28" (internal sensor, °C) |
+
+Every word in the table is a word the SoC accepts and answers with a different function.
+`echo_bad` stayed 0 throughout the session (final count: 24 valid echoes, 0 bad).
+
+### 5d. Loads, hand-decoded (their decoder's output alongside, for PR (2))
+
+| load | submode | frame[2..7] | 7-seg text | reading | their decoder |
+|---|---|---|---|---|---|
+| Li cell | 0 DCV | `86 FF EF A7 0D 00` f8=02 | `3.862` | 3.862 V | 3.862 V ✅ |
+| Li cell | 8 Diode | `00 F0 6B 01 80 00` f8=02 | ` 0L ` | OL (above diode range) | `---` |
+| Li cell | 1 ACV | `E5 EB EB EB 0B 00` f8=82 | `0000` | 0 (DC source) | `---`, reject=3 |
+| 2.2 kΩ | 6 Ω | `A4 0D EA E7 4F 20` | `2168` | 2168 Ω | 2.168 kOhm ✅ |
+| 2.2 kΩ | 7 Cont | `00 E0 7B 01 00 28` | ` 0L ` | open (above threshold) | `ERR` |
+| 10 kΩ | 6 Ω | `C4 DF AF 4D 4E 20` | `9.924` | 9.924 kΩ | 9.924 kOhm ✅ |
+| 300 kΩ | 6 Ω | `A4 CD 8F EA 0F 24` | `2978` | 297.8 kΩ (f7=0x24: ×100 Ω) | `---`, reject=4 |
+| short | 6 Ω | `04 E0 1B 8A 0A 20` | ` 0.17` | 0.17 Ω | `ERR` |
+| short | 7 Cont | `00 E0 1B 8A 0A 28` | ` 0.17` | 0.17 Ω | `ERR` |
+| 10 nF | 9 Cap | `C4 FF A7 8D 2F 10` | `9.623` | 9.62 nF (f6=0x2_) | 962.3 nF ✗ (×100) |
+| 10 µF | 9 Cap | `C4 FF C7 8F 1A 10` | `9.697` | 9.70 µF (f6=0x1_) | 969.7 nF ✗ (unit, ×100) |
+
+Two things the table says about decoding, both for PR (2): the decimal point is in the
+frame and it moves with the range (`2168` has none, `9.924` has one, both under
+`f6 = 0x4_`); and the capacitance unit is the upper nibble of `f6`.
+
+### 5e. Keepalive is silent; obeyed words are what click
+
+Operator listening, labelled as such, with the relay pose read back over the shell before
+and after each step:
+
+| phase | what | clicks heard | our relay pose |
+|---|---|---|---|
+| 30 s in DCV, keepalive only (129 frames) | — | **0** | unchanged |
+| scope → meter | entry | 3 | changed (scope pose → meter pose) |
+| DC mA → DC A (2→3) | function change | **2** | **unchanged** |
+| Cap → Temp (9→10) | function change | 0 | unchanged |
+
+The 2→3 row is the interesting one: our MCU moved no pin, yet something clicked twice.
+The SoC switches its own relays when a word is obeyed — consistent with the stock logger
+result in #15 (stock's MCU moves no frontend pin across 40 function changes) — and it does
+so only for functions that need it.
+
+### 5f. Scope is undisturbed
+
+SPI3 reads in scope mode: 15.3/s before a scope→meter→scope cycle, 14.2/s after, 0
+timeouts, CH1 acquiring.
+
+## 6. Blind spots
+
+1. **The scope-side control is vacuous on this flavour.** With `FPGA_USART_SILENT_SCOPE=1`
+   nothing is transmitted in scope mode, so "scope traffic causes no echoes" was not
+   tested here. On a flavour that does drive USART2 in scope mode, the scope words go out
+   unobeyed by construction (`fpga_timed_send_cmd`), but the SoC's reaction to an obeyed
+   non-`0x05` frame remains unmeasured.
+2. **No current source, no AC source, no thermocouple.** For submodes 1–5 and 10 only the
+   word's acceptance and the frame signature are established; no value was checked.
+3. **Loads are ±5 % parts and an unlabelled cell**; readings are physically sensible, not
+   calibrated. The cell read 3.86 V, so it is not the alkaline AA it was assumed to be.
+4. **Wake time is one unit's constant.** 1380 ms on 24 transitions here says nothing about
+   unit #1 or about supply/temperature dependence; the 3 s timeout has 2.2× margin on
+   this unit only.
+5. **Relay clicks are ear-counted**, with pose readback as the only instrument. The 3-click
+   entry was not decomposed into PC11 vs relay pose vs SoC.
+6. **Only one obeyed word per transition was tested.** Whether the SoC accepts a second
+   word without a PC11 restart (it did by hand, in EXP-27 and here) is not what the
+   production path does now — the production path restarts the SoC every time.
+
+## 7. Conclusion
+
+- **Established:** with the header on and the measured table, `mode meter N` selects
+  function N for all eleven submodes — one accepted echo per transition, zero bad echoes,
+  frame signature per function, first-try confirmation on 24/24 transitions after the two
+  fixes. The unobeyed keepalive produces no echoes and no relay actuation over 30 s.
+  Header off → the SoC ignores the transition (negative control holds).
+- **Established, new:** `fpga_meter_reset_transport()` restarts the SoC (PC11), which then
+  needs 1380 ms before it hears anything. A transition that sends its selector 20 ms after
+  PC11 selects nothing. This was true of every transition before this PR and was invisible
+  because nothing was ever obeyed.
+- **Established, new:** the transport reset could inherit a disabled transceiver from the
+  scope-mode park and re-enable USART2 without TE/RE (`CTRL1=0x20A0`), about one entry in
+  three from the shell. Fixed by making the reset own TE/RE/IRQ.
+- **Excluded:** the keepalive as a source of relay actuation; scope disturbance from a
+  meter cycle at the SPI3-rate level.
+- **NOT excluded (explicitly):** the SoC's reaction to obeyed non-`0x05` words; the wake
+  constant on other units; whether dropping PC11 on function changes is needed at all
+  (stock does not, per the #15 logger) — that would remove the 1.4 s per change, and it is
+  a transport-shape decision for the maintainer.
+- **Follow-up:** PR (2) (decoder: frame decimal point, capacitance unit, both OL spellings,
+  the `f7=0x24` band); PR (3) (the stock logger); EXP-26's "transmit stopped → 0 frames"
+  arm was `mode scope`, which also drops PC11 — worth re-running with PC11 held high to
+  separate "answers traffic" from "was powered".

--- a/docs/stock_vs_openscope.md
+++ b/docs/stock_vs_openscope.md
@@ -62,8 +62,8 @@ Legend: ✅ works · ⚠️ partial / caveated · 🔬 code exists but is not re
 | Persistence / math channels | ✅ / — | 🔬 | Implemented, but they render a synthetic sine rather than the live trace |
 | XY, roll, trend, mask test | partial | 🔬 | Compiled libraries with no UI path |
 | **Multimeter** | | | |
-| DCV / ACV / current / resistance / continuity / diode / capacitance | ✅ | ✅ | 10 sub-modes, real data over USART2 |
-| Temperature | ✅ | ❌ | No sub-mode for it |
+| DCV / ACV / current / resistance / continuity / diode / capacitance | ✅ | ⚠️ | 10 sub-modes **selected** with the meter SoC's measured word map (issue #15). Read back so far: DCV and resistance. The other frame families still wait for the decoder |
+| Temperature | ✅ | ⚠️ | Sub-mode 10 selects it (`0x0512`); the reading is not decoded yet |
 | Chart (strip-chart) view | ❌ | ✅ | 300-sample scrolling trace, auto-scaled |
 | Stats view (histogram, min/max/avg) | ❌ | ✅ | 20-bin histogram |
 | Fuse-drop / parasitic-drain tester | ❌ | ✅ | 5 fuse types, 47 ratings, 3 sub-views |

--- a/firmware/src/drivers/fpga.c
+++ b/firmware/src/drivers/fpga.c
@@ -265,6 +265,20 @@ static void fpga_meter_reset_transport(void)
 
     USART2->ctrl1 = (ctrl1 | USART_CTRL1_UEN | USART_CTRL1_RDBFIEN) &
                     ~USART_CTRL1_TDBEIEN;
+    /*
+     * Do not inherit a dead transceiver (EXP-205, unit #2). On a silent-scope
+     * build, scope entry parks USART2 with ctrl1 = 0 and the IRQ masked. When
+     * a meter transition runs before fpga_set_meter_mux(true) has re-armed it
+     * -- a race the shell's `mode meter` loses about one time in three -- the
+     * restore above re-enables UEN and RDBFIEN on a ctrl1 that had TE and RE
+     * clear, with the NVIC line still masked: TX count climbs, the wire is
+     * dark, the SoC never speaks, and every selector retry times out
+     * (measured: CTRL1 0x20A0 in the failed state, 0x202C in the good one).
+     * The transition is about to talk to the SoC, so it owns the transceiver.
+     */
+    USART2->ctrl1 |= (1U << 2) | (1U << 3);   /* RE, TE */
+    NVIC_SetPriority(USART2_IRQn, 5);
+    NVIC_EnableIRQ(USART2_IRQn);
 
     if (rx_task_handle != NULL) vTaskResume(rx_task_handle);
     if (tx_task_handle != NULL) vTaskResume(tx_task_handle);
@@ -6138,6 +6152,85 @@ void fpga_enter_siggen_mode(void)
     GPIOE->clr = (1U << 6);   /* PE6 LOW */
 }
 
+/*
+ * THE SoC RESTARTS ON EVERY TRANSITION, AND IT IS DEAF WHILE IT BOOTS.
+ *
+ * Measured on unit #2 with the AA 55 header live (2026-09-13, EXP-205):
+ * fpga_meter_reset_transport() drops PC11, and the meter SoC comes back in its
+ * power-on Auto state -- the frame after a transition is the boot-time "Auto"
+ * text again, whatever function had been selected before. Then the selector
+ * sent 20 ms later is swallowed: `AA 55 05 0B` left the wire (tx_control
+ * history) and no echo ever came back, while not one data frame arrived
+ * during the whole sequence (transition history data=558..558). The same word
+ * typed by hand a second later was echoed at once and switched the function.
+ *
+ * So the transition waits for the SoC to speak before it commands it, and it
+ * does not take the selector on trust: it re-sends until the echo confirms it.
+ * The wait feeds unobeyed keepalive traffic, since a silent wire is the other
+ * documented way to get no frames (EXP-26). Numbers are exported for
+ * `meter hdr`, so the wake time and the retry count are measurements, not
+ * assumptions.
+ */
+#define FPGA_METER_SOC_WAKE_TIMEOUT_MS   3000u  /* measured wake 1380 ms; one
+                                                   * boot->meter entry missed 1500 */
+#define FPGA_METER_SOC_WAKE_SETTLE_MS     200u
+#define FPGA_METER_SOC_WAKE_POLL_MS        10u
+#define FPGA_METER_SELECTOR_ECHO_WAIT_MS  300u
+#define FPGA_METER_SELECTOR_TRIES           5u
+
+static void fpga_meter_wait_for_soc(uint16_t frame_before)
+{
+    uint32_t waited = 0;
+    uint32_t since_keepalive = 0;
+
+    fpga.meter_soc_wake_ms = 0xFFFFu;  /* timeout until proven otherwise */
+    while (waited < FPGA_METER_SOC_WAKE_TIMEOUT_MS) {
+        if (fpga.frame_count != frame_before) {
+            fpga.meter_soc_wake_ms = (uint16_t)waited;
+            break;
+        }
+        if (waited + FPGA_METER_SOC_WAKE_POLL_MS >= FPGA_METER_SOC_WAKE_TIMEOUT_MS) {
+            fpga.meter_soc_wake_timeouts++;
+        }
+        if (since_keepalive >= 250u) {
+            (void)fpga_send_cmd_unobeyed(0x05, FPGA_CMD_METER_START);
+            since_keepalive = 0;
+        }
+        fpga_scope_delay_ms(FPGA_METER_SOC_WAKE_POLL_MS);
+        waited += FPGA_METER_SOC_WAKE_POLL_MS;
+        since_keepalive += FPGA_METER_SOC_WAKE_POLL_MS;
+    }
+    fpga_scope_delay_ms(FPGA_METER_SOC_WAKE_SETTLE_MS);
+}
+
+/* Send the selector OBEYED and wait for its echo; retry a bounded number of
+ * times. Leaves the outcome in fpga.meter_selector_attempts / _confirmed. */
+static void fpga_send_selector_confirmed(uint16_t word, uint32_t settle_ms)
+{
+    fpga.meter_selector_attempts = 0;
+    fpga.meter_selector_confirmed = 0;
+    for (uint8_t attempt = 0; attempt < FPGA_METER_SELECTOR_TRIES; attempt++) {
+        uint16_t echo_before = fpga.rx_echo_valid_count;
+        uint32_t waited = 0;
+
+        fpga.meter_selector_attempts++;
+        fpga_wire_send_word(word, 0);
+        while (waited < FPGA_METER_SELECTOR_ECHO_WAIT_MS) {
+            if (fpga.rx_echo_valid_count != echo_before) {
+                fpga.meter_selector_confirmed = 1;
+                break;
+            }
+            fpga_scope_delay_ms(FPGA_METER_SOC_WAKE_POLL_MS);
+            waited += FPGA_METER_SOC_WAKE_POLL_MS;
+        }
+        if (fpga.meter_selector_confirmed) break;
+    }
+    if (!fpga.meter_selector_confirmed) {
+        fpga.meter_selector_unconfirmed_total++;
+    }
+    fpga_scope_delay_ms(settle_ms);
+}
+
 /* Helper: send the stock PC7-gated command tail (shared by meter modes). */
 static void fpga_timed_send_probe_detect(uint32_t delay_ms)
 {
@@ -6197,7 +6290,7 @@ static void fpga_send_meter_mode_sequence(uint8_t submode)
      * selector, and 0x0509 puts the SoC's display into a state that is not a
      * measurement. Obeyed, either would undo the selector a few ms later.
      */
-    fpga_wire_send_word(plan.selector_word, plan.settle_ms);
+    fpga_send_selector_confirmed(plan.selector_word, plan.settle_ms);
     if (plan.has_probe_detect) {
         fpga_timed_send_probe_detect(10);
     }
@@ -6245,6 +6338,7 @@ static void fpga_apply_meter_transition(uint8_t submode, bool wake_preamble)
     fpga_set_meter_frontend_for_submode(submode);
     actual_gpio = fpga_meter_mux_gpio_mask_live();
     fpga_scope_delay_ms(plan.settle_ms);
+    fpga_meter_wait_for_soc(frame_before);
     fpga_send_meter_mode_sequence(submode);
     fpga_record_meter_transition_snapshot(submode, &plan, planned_gpio,
                                           actual_gpio, tx_before, frame_before);

--- a/firmware/src/drivers/fpga.c
+++ b/firmware/src/drivers/fpga.c
@@ -1167,19 +1167,26 @@ static void fpga_capture_meter_first_rx_latch(void)
  * Format: [hdr0][hdr1] [cmd_hi][cmd_lo] [0..0] [checksum]
  * Checksum = (cmd_hi + cmd_lo) & 0xFF
  *
- * THE HEADER IS THE OPEN QUESTION (EXP-25, issue #15). We have always sent
- * 00 00 here. Stlkv measured on unit #2 (2026-09-07) that the meter SoC
- * requires AA 55: with AA 55 it echoes every accepted word and switches
- * function; with 00 00 it stays silent and holds its power-on auto mode.
- * That would explain `echo_frames` sitting at 0 since EXP-05, and it would
- * mean every meter reading this project has taken was auto mode.
+ * THE HEADER IS AA 55 (issue #15; EXP-25 replicated it on unit #1 A/B/A/B/A,
+ * echoes 0/3/0/3/0). With AA 55 the meter SoC echoes every accepted word and
+ * switches function; with 00 00 -- what this project sent from 2026-04 to
+ * 2026-09 -- it stays silent and holds its power-on auto mode. That is why
+ * `echo_frames` sat at 0 since EXP-05 and why every meter reading before
+ * 2026-09-12 was the SoC's auto mode, whatever the UI said.
  *
- * Runtime-toggleable (`meter hdr on|off`) so the comparison runs A/B/A inside
- * one boot: same probe, same cell, same build, ONE variable. It defaults OFF
- * so the device boots bit-identical to the one that took every earlier
- * measurement, and so the baseline is a measurement rather than a memory.
+ * The header defaults ON, and it landed in the same commit as the corrected
+ * word table: with a wrong table an obeyed frame is worse than a discarded
+ * one. `meter hdr off` remains as the NEGATIVE CONTROL for the bench (a
+ * transition under 00 00 must produce zero echoes and leave the SoC's
+ * function where it was).
+ *
+ * The header only goes on frames sent OBEYED (FPGA_TX_OBEY_BIT). Everything
+ * this firmware transmitted before 2026-09-12 as scope/siggen/config traffic
+ * still goes out 00 00, bit-identical to the traffic the SoC answered for five
+ * months, so the flip changes exactly one thing on the wire: the selector
+ * word of a meter transition, plus whatever the operator sends by hand.
  */
-static volatile bool meter_tx_header_aa55 = false;
+static volatile bool meter_tx_header_aa55 = true;
 
 void fpga_meter_tx_header_set(bool aa55) { meter_tx_header_aa55 = aa55; }
 bool fpga_meter_tx_header_get(void)      { return meter_tx_header_aa55; }
@@ -1214,14 +1221,20 @@ static void meter_build_tx_frame(uint8_t *frame, uint8_t cmd_hi, uint8_t cmd_lo,
     frame[9] = (cmd_lo + cmd_hi) & 0xFF;
 }
 
-static void usart2_send_cmd(uint8_t cmd_hi, uint8_t cmd_lo)
+static void usart2_send_cmd_ex(uint8_t cmd_hi, uint8_t cmd_lo, bool obey)
 {
     uint8_t frame[FPGA_TX_FRAME_SIZE];
     fpga_record_tx_cmd(cmd_hi, cmd_lo);
     fpga.tx_count++;
-    meter_build_tx_frame(frame, cmd_hi, cmd_lo, true);
+    meter_build_tx_frame(frame, cmd_hi, cmd_lo, obey);
     fpga_record_tx_frame(frame);
     usart2_send_frame(frame);
+}
+
+/* Polled, OBEYED: a deliberate command to the meter SoC. */
+static void usart2_send_cmd(uint8_t cmd_hi, uint8_t cmd_lo)
+{
+    usart2_send_cmd_ex(cmd_hi, cmd_lo, true);
 }
 
 /* ═══════════════════════════════════════════════════════════════════
@@ -1258,19 +1271,40 @@ static void fpga_scope_delay_ms(uint32_t ms)
     }
 }
 
-static void fpga_timed_send_cmd(uint8_t cmd_hi, uint8_t cmd_lo, uint32_t delay_ms)
+static void fpga_timed_send_cmd_ex(uint8_t cmd_hi, uint8_t cmd_lo,
+                                   uint32_t delay_ms, bool obey)
 {
     if (xTaskGetSchedulerState() == taskSCHEDULER_RUNNING && usart_tx_queue != NULL) {
-        uint32_t item = ((uint32_t)cmd_hi << 8) | cmd_lo | FPGA_TX_OBEY_BIT;
+        uint32_t item = ((uint32_t)cmd_hi << 8) | cmd_lo |
+                        (obey ? FPGA_TX_OBEY_BIT : 0U);
 
         /* Scope reinit is a deliberate control path, so it's worth waiting
          * briefly for queue space instead of silently dropping commands. */
         (void)xQueueSend(usart_tx_queue, &item, pdMS_TO_TICKS(100));
     } else {
-        usart2_send_cmd(cmd_hi, cmd_lo);
+        usart2_send_cmd_ex(cmd_hi, cmd_lo, obey);
     }
 
     fpga_scope_delay_ms(delay_ms);
+}
+
+/*
+ * Timed send, UNOBEYED (00 00 header).
+ *
+ * This is the path every scope, siggen and mode-entry sequence in this file has
+ * always used, and until 2026-09-12 all of it went out 00 00 and was discarded
+ * by the meter SoC while still soliciting its data frames (EXP-26: the SoC
+ * answers traffic, not commands). Keeping it unobeyed keeps that wire
+ * bit-identical now that the header is real. What would otherwise have become
+ * live the moment the header flipped: 0x050A (Capacitance) as the "PC7-low
+ * probe tail", 0x0514 (Auto) as "variant setup", 0x0509 (a display state),
+ * 0x0508, the 0x00 0x2C bank prefix, and every non-0x05 scope word whose
+ * effect on the SoC nobody has measured. A command to the SoC is sent with
+ * fpga_wire_send_word() or fpga_send_cmd() instead.
+ */
+static void fpga_timed_send_cmd(uint8_t cmd_hi, uint8_t cmd_lo, uint32_t delay_ms)
+{
+    fpga_timed_send_cmd_ex(cmd_hi, cmd_lo, delay_ms, false);
 }
 
 static void fpga_scope_select_timing(const scope_state_t *ss,
@@ -1285,7 +1319,27 @@ static uint8_t fpga_scope_trigger_lsb(const scope_state_t *ss);
 static uint8_t fpga_scope_trigger_mode_byte(const scope_state_t *ss);
 static uint8_t fpga_scope_prefix_cmd(const scope_state_t *ss);
 
+/* A stock word to the meter SoC, OBEYED (AA 55 when the header is on). This is
+ * what a meter transition's selector, the debug boot-order replay's selector
+ * and the shell's `fpga wire words` use. The batch replays use the unobeyed
+ * variant below. */
 void fpga_wire_send_word(uint16_t word, uint32_t delay_ms)
+{
+    fpga_timed_send_cmd_ex((uint8_t)(word >> 8), (uint8_t)(word & 0xFF),
+                           delay_ms, true);
+}
+
+/*
+ * The shell's stock-shape replays (`fpga wire entry/scope`, `spi3 scopetest`,
+ * `stock diag bridge`) go through this UNOBEYED variant. They exist to probe
+ * the FPGA config-entry path by reproducing stock's USART2 byte stream, not to
+ * command the meter -- and their bank words are eight live meter function
+ * selectors (DCV, Diode, DC A, DC mA / ACV, Continuity, AC mA, AC A) plus
+ * 0x0501 (Auto) and 0x0503 (unmeasured). Obeyed, one `fpga wire entry` would
+ * walk the SoC through five functions. A word meant for the SoC is sent with
+ * `fpga wire words`, which stays obeyed.
+ */
+static void fpga_wire_send_word_unobeyed(uint16_t word, uint32_t delay_ms)
 {
     fpga_timed_send_cmd((uint8_t)(word >> 8), (uint8_t)(word & 0xFF), delay_ms);
 }
@@ -1297,13 +1351,13 @@ static void fpga_wire_send_bank_words(uint8_t bank_mode)
 
     if (bank_mode == 0 || bank_mode == 2) {
         for (size_t i = 0; i < sizeof(ch1_words) / sizeof(ch1_words[0]); i++) {
-            fpga_wire_send_word(ch1_words[i], 15);
+            fpga_wire_send_word_unobeyed(ch1_words[i], 15);
         }
     }
 
     if (bank_mode == 1 || bank_mode == 2) {
         for (size_t i = 0; i < sizeof(ch2_words) / sizeof(ch2_words[0]); i++) {
-            fpga_wire_send_word(ch2_words[i], 15);
+            fpga_wire_send_word_unobeyed(ch2_words[i], 15);
         }
     }
 }
@@ -1342,10 +1396,10 @@ void fpga_wire_entry(uint8_t bank_mode)
 {
     if (!fpga.initialized) return;
 
-    fpga_wire_send_word(0x02A0, 20);
-    fpga_wire_send_word(0x0501, 15);
+    fpga_wire_send_word_unobeyed(0x02A0, 20);
+    fpga_wire_send_word_unobeyed(0x0501, 15);
     fpga_wire_send_bank_words(bank_mode);
-    fpga_wire_send_word(0x0503, 20);
+    fpga_wire_send_word_unobeyed(0x0503, 20);
 }
 
 void fpga_wire_scope_sequence(uint8_t bank_mode)
@@ -1529,7 +1583,7 @@ void fpga_stock_diag_bridge_fixed(void)
      * 0x0501 materializer family around 0x08006060. */
     fpga_timed_send_cmd(0x00, 0x13, 15);
     fpga_timed_send_cmd(0x00, 0x14, 20);
-    fpga_wire_send_word(0x0501, 15);
+    fpga_wire_send_word_unobeyed(0x0501, 15);
     fpga_timed_send_cmd(0x00, 0x1D, 15);
     fpga_timed_send_cmd(0x00, 0x1B, 20);
 }
@@ -1876,6 +1930,10 @@ static void fpga_send_meter_wake_preamble(void)
      *
      * That is stock command sequencing evidence only. It is not a recovered
      * analog range writer, low-DCV correction, or factory calibration source.
+     *
+     * All four go out UNOBEYED (fpga_timed_send_cmd): obeyed, 0x0A would
+     * select Capacitance and 0x14 would select Auto right before the
+     * transition sends the real selector.
      */
     fpga_timed_send_cmd(0x05, 0x08, 10);
     fpga_timed_send_cmd(0x05, FPGA_CMD_METER_START, 10);
@@ -2595,12 +2653,15 @@ static void fpga_meter_poll_task(void *pv)
                 /* Stock's meter activation, sent once on entry rather than at
                  * boot — a scope build never runs fpga_init's meter block. */
                 fpga_meter_needs_activation = false;
-                usart2_send_cmd(0x05, 0x08);  vTaskDelay(pdMS_TO_TICKS(10));
-                usart2_send_cmd(0x05, 0x09);  vTaskDelay(pdMS_TO_TICKS(10));
-                if (GPIOC->idt & (1U << 7)) usart2_send_cmd(0x05, 0x07);
-                else                        usart2_send_cmd(0x05, 0x0A);
+                /* Unobeyed, same reason as fpga_init's copy: 0x0A selects
+                 * Capacitance and 0x14 selects Auto when obeyed, and this
+                 * runs right after the transition's real selector. */
+                usart2_send_cmd_ex(0x05, 0x08, false);  vTaskDelay(pdMS_TO_TICKS(10));
+                usart2_send_cmd_ex(0x05, 0x09, false);  vTaskDelay(pdMS_TO_TICKS(10));
+                if (GPIOC->idt & (1U << 7)) usart2_send_cmd_ex(0x05, 0x07, false);
+                else                        usart2_send_cmd_ex(0x05, 0x0A, false);
                 vTaskDelay(pdMS_TO_TICKS(10));
-                usart2_send_cmd(0x05, 0x14);  vTaskDelay(pdMS_TO_TICKS(50));
+                usart2_send_cmd_ex(0x05, 0x14, false);  vTaskDelay(pdMS_TO_TICKS(50));
             }
             fpga_send_meter_poll_sequence(meter_submode);
         }
@@ -5539,20 +5600,23 @@ void fpga_init(void)
      * Stock firmware TX queue items: 0x0508, 0x0509, 0x0507, 0x0514.
      * This was discovered by tracing direct TX queue writes in the binary. */
 #if !FPGA_USART_SILENT_SCOPE
-    usart2_send_cmd(0x05, 0x08);  /* Meter: configure */
+    /* All UNOBEYED (00 00 header): 0x0A is the SoC's Capacitance selector and
+     * 0x14 is Auto -- obeyed at boot they would pick a function before the
+     * UI does. The block stays as traffic because that is what it always was. */
+    usart2_send_cmd_ex(0x05, 0x08, false);  /* "configure" -- a display word */
     systick_delay_ms(10);
-    usart2_send_cmd(0x05, 0x09);  /* Meter: start measurement */
+    usart2_send_cmd_ex(0x05, 0x09, false);  /* "start" -- a display word */
     systick_delay_ms(10);
 
     /* Stock PC7 command tail: high -> 0x07, low -> 0x0A. */
     if (GPIOC->idt & (1U << 7)) {
-        usart2_send_cmd(0x05, 0x07);
+        usart2_send_cmd_ex(0x05, 0x07, false);
     } else {
-        usart2_send_cmd(0x05, 0x0A);
+        usart2_send_cmd_ex(0x05, 0x0A, false);
     }
     systick_delay_ms(10);
 
-    usart2_send_cmd(0x05, 0x14);  /* Meter variant setup */
+    usart2_send_cmd_ex(0x05, 0x14, false);  /* Auto */
     systick_delay_ms(50);
 
     /*
@@ -5693,14 +5757,19 @@ BaseType_t fpga_send_cmd(uint8_t cmd_high, uint8_t cmd_low)
     return pdTRUE;
 }
 
-BaseType_t fpga_send_cmd_keepalive(uint8_t cmd_high, uint8_t cmd_low)
+BaseType_t fpga_send_cmd_unobeyed(uint8_t cmd_high, uint8_t cmd_low)
 {
     if (usart_tx_queue != NULL &&
         xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) {
         uint32_t item = ((uint32_t)cmd_high << 8) | cmd_low;  /* OBEY clear */
         return xQueueSend(usart_tx_queue, &item, 0);
     }
-    return pdFALSE;  /* keepalive is best-effort; never block the poll task */
+    return pdFALSE;  /* best-effort; never block the caller */
+}
+
+BaseType_t fpga_send_cmd_keepalive(uint8_t cmd_high, uint8_t cmd_low)
+{
+    return fpga_send_cmd_unobeyed(cmd_high, cmd_low);
 }
 
 bool fpga_usart_tx_task_exists(void)
@@ -6038,22 +6107,24 @@ void fpga_enter_siggen_mode(void)
      * 0x14 = meter variant setup
      * 0x09 = meter start measurement
      * 0x07/0x0A = stock PC7 command tail, not a DMM range state */
-    fpga_send_cmd(0x00, 0x02);  /* Siggen: frequency */
-    fpga_send_cmd(0x00, 0x03);  /* Siggen: waveform */
-    fpga_send_cmd(0x00, 0x04);  /* Siggen: amplitude */
-    fpga_send_cmd(0x00, 0x05);  /* Siggen: offset */
-    fpga_send_cmd(0x00, 0x06);  /* Siggen: duty cycle */
-    fpga_send_cmd(0x00, 0x08);  /* Shared meter configure/setup byte */
+    /* Unobeyed: this block has always gone out 00 00 and the SoC's reaction
+     * to AA 55 frames with a 0x00 high byte has never been measured. */
+    fpga_send_cmd_unobeyed(0x00, 0x02);  /* Siggen: frequency */
+    fpga_send_cmd_unobeyed(0x00, 0x03);  /* Siggen: waveform */
+    fpga_send_cmd_unobeyed(0x00, 0x04);  /* Siggen: amplitude */
+    fpga_send_cmd_unobeyed(0x00, 0x05);  /* Siggen: offset */
+    fpga_send_cmd_unobeyed(0x00, 0x06);  /* Siggen: duty cycle */
+    fpga_send_cmd_unobeyed(0x00, 0x08);  /* Shared meter configure/setup byte */
 
     /* Case 9 tail: meter variant + stock PC7 command tail */
-    fpga_send_cmd(0x00, 0x14);
-    fpga_send_cmd(0x00, FPGA_CMD_METER_START);
+    fpga_send_cmd_unobeyed(0x00, 0x14);
+    fpga_send_cmd_unobeyed(0x00, FPGA_CMD_METER_START);
 
     /* Stock PC7 command tail: high -> 0x07, low -> 0x0A. */
     if (GPIOC->idt & (1U << 7)) {
-        fpga_send_cmd(0x00, 0x07);
+        fpga_send_cmd_unobeyed(0x00, 0x07);
     } else {
-        fpga_send_cmd(0x00, FPGA_CMD_METER_NOPROBE);
+        fpga_send_cmd_unobeyed(0x00, FPGA_CMD_METER_NOPROBE);
     }
 
     /* Switch analog MUX for signal gen output.
@@ -6094,7 +6165,7 @@ static void fpga_send_meter_mode_sequence(uint8_t submode)
     fpga.meter_mode_sequence_submode = submode;
     fpga.meter_mode_config_word = 0;
     fpga.meter_mode_selector_word = plan.selector_word;
-    fpga.meter_mode_apply_word = 0;
+    fpga.meter_mode_apply_word = plan.apply_word;  /* always 0 now, see plan */
     fpga.meter_mode_probe_word = plan.has_probe_detect ? probe_word : 0;
     fpga.meter_mode_start_word = plan.start_word;
     /*
@@ -6115,13 +6186,18 @@ static void fpga_send_meter_mode_sequence(uint8_t submode)
     }
     if (plan.has_config_word) {
         fpga.meter_mode_config_word = plan.config_word;
-        fpga_wire_send_word(plan.config_word, plan.settle_ms);
+        fpga_timed_send_cmd((uint8_t)(plan.config_word >> 8),
+                            (uint8_t)(plan.config_word & 0x00FFU),
+                            plan.settle_ms);
     }
+    /*
+     * THE ONE OBEYED WORD of a transition. Everything around it (bank prefix,
+     * 0x0508, the probe tail, 0x0509) keeps the 00 00 header it always had:
+     * the probe tail's low branch is 0x0A, which is the SoC's Capacitance
+     * selector, and 0x0509 puts the SoC's display into a state that is not a
+     * measurement. Obeyed, either would undo the selector a few ms later.
+     */
     fpga_wire_send_word(plan.selector_word, plan.settle_ms);
-    if (plan.has_apply_word) {
-        fpga.meter_mode_apply_word = plan.apply_word;
-        fpga_wire_send_word(plan.apply_word, plan.settle_ms);
-    }
     if (plan.has_probe_detect) {
         fpga_timed_send_probe_detect(10);
     }

--- a/firmware/src/drivers/fpga.h
+++ b/firmware/src/drivers/fpga.h
@@ -60,8 +60,12 @@
 /* Runtime commands */
 #define FPGA_CMD_RESET        0x00
 #define FPGA_CMD_SCOPE_CH     0x01   /* Scope channel config */
-#define FPGA_CMD_METER_START  0x09   /* Start meter measurement */
-#define FPGA_CMD_METER_NOPROBE 0x0A  /* Meter PC7-low command tail */
+#define FPGA_CMD_METER_START  0x09   /* Legacy name. Obeyed, 0x0509 puts the SoC's
+                                      * display into a non-measurement state ("EF");
+                                      * sent unobeyed it is keepalive traffic. */
+#define FPGA_CMD_METER_NOPROBE 0x0A  /* Legacy name for the "PC7-low tail". 0x050A is
+                                      * the SoC's CAPACITANCE selector (issue #15);
+                                      * never send it obeyed outside a transition. */
 
 /* Scope configuration commands (case 0 of mode init dispatcher FUN_0800b908).
  * Sent as a sequence when entering oscilloscope mode: 0x0B-0x11.
@@ -75,10 +79,12 @@
 #define FPGA_CMD_SCOPE_CFG_10 0x10   /* Scope config: timebase period */
 #define FPGA_CMD_SCOPE_CFG_11 0x11   /* Scope config: timebase mode */
 
-/* Meter variant setup (system_mode 9: resistance) */
-#define FPGA_CMD_METER_VAR_12 0x12   /* Meter variant config */
-#define FPGA_CMD_METER_VAR_13 0x13   /* Meter variant config */
-#define FPGA_CMD_METER_VAR_14 0x14   /* Meter variant config */
+/* Legacy "meter variant" names. Measured (issue #15): these are function
+ * selectors of the meter SoC, not variant setup. The canonical per-submode
+ * table is stock_meter_word_low_for_submode[] in fpga_meter_plan.c. */
+#define FPGA_CMD_METER_VAR_12 0x12   /* Temperature */
+#define FPGA_CMD_METER_VAR_13 0x13   /* LIVE (NCV screen; frame is the text "L1uE") */
+#define FPGA_CMD_METER_VAR_14 0x14   /* Auto -- the SoC's own autorange-everything */
 
 /* Scope channel command family 0x1A..0x1E. Stock scope xrefs use these as
  * channel gain/offset/coupling commands. The DMM boot dispatcher also queues
@@ -676,10 +682,12 @@ BaseType_t fpga_send_cmd(uint8_t cmd_high, uint8_t cmd_low);
  */
 bool fpga_usart_tx_task_exists(void);
 
-/* Meter TX frame header A/B (EXP-25, issue #15). Default false = 00 00, the
- * header every measurement before 2026-09-12 was taken with. True = AA 55,
- * which Stlkv measured as the header the meter SoC actually requires. */
+/* Meter TX frame header (EXP-25, issue #15). Default true = AA 55, the header
+ * the meter SoC requires (measured on two units). False = 00 00, the header
+ * every measurement before 2026-09-12 was taken with; kept as the bench's
+ * negative control (`meter hdr off`). */
 /* usart_tx_queue item: bits 0-7 cmd_lo, 8-15 cmd_hi, bit 16 = OBEY.
+ * OBEY set   means "a command to the meter SoC": AA 55 while the header is on.
  * OBEY clear means "send this frame with the 00 00 header the meter ignores".
  * That is not a hack — EXP-25 measured that the meter emits data frames in
  * response to USART TRAFFIC, not to commands it accepts (header off, zero
@@ -690,6 +698,12 @@ bool fpga_usart_tx_task_exists(void);
 
 void fpga_meter_tx_header_set(bool aa55);
 bool fpga_meter_tx_header_get(void);
+
+/* Queue a frame UNOBEYED: 00 00 header regardless of the header setting. For
+ * traffic that has always gone out 00 00 and must stay bit-identical now that
+ * obeyed frames are real (legacy scope/siggen/config words, diagnostics that
+ * replay stock's byte stream without meaning to switch the meter). */
+BaseType_t fpga_send_cmd_unobeyed(uint8_t cmd_high, uint8_t cmd_low);
 
 /* Keepalive send: solicits a data frame without being obeyed. */
 BaseType_t fpga_send_cmd_keepalive(uint8_t cmd_high, uint8_t cmd_low);
@@ -1012,6 +1026,12 @@ void fpga_stock_diag_bridge_dynamic(uint8_t bank_mode);
  *   1 = CH2 candidate bank
  *   2 = CH1 + CH2 candidate banks
  */
+/* fpga_wire_send_word() is OBEYED: with the AA 55 header on, a 0x05xx word
+ * sent here switches the meter SoC's function (`fpga wire words`). The batch
+ * replays -- fpga_wire_entry(), fpga_wire_scope_sequence() and the stock-diag
+ * bridges -- send their words UNOBEYED: they probe the FPGA config-entry path
+ * with stock's byte stream, and their bank words are eight live meter
+ * selectors plus 0x0501 (Auto) and 0x0503 (unmeasured). Shell only. */
 void fpga_wire_send_word(uint16_t word, uint32_t delay_ms);
 void fpga_wire_entry(uint8_t bank_mode);
 void fpga_wire_scope_sequence(uint8_t bank_mode);

--- a/firmware/src/drivers/fpga.h
+++ b/firmware/src/drivers/fpga.h
@@ -237,6 +237,14 @@ typedef struct {
      * its echo, which made good echoes fail validation (EXP-27). */
     volatile uint8_t  last_obeyed_tx_lo;
     volatile bool     last_obeyed_tx_valid;
+    /* Last meter transition (EXP-205): ms from PC11 back up to the SoC's first
+     * data frame (0xFFFF = timed out), selector sends until its echo, whether
+     * it was confirmed, and how many transitions ended unconfirmed. */
+    volatile uint16_t meter_soc_wake_ms;
+    volatile uint8_t  meter_selector_attempts;
+    volatile uint8_t  meter_selector_confirmed;
+    volatile uint16_t meter_selector_unconfirmed_total;
+    volatile uint16_t meter_soc_wake_timeouts;
     volatile uint8_t  tx_frame_history[FPGA_TX_FRAME_HISTORY][FPGA_TX_FRAME_SIZE];
     volatile uint16_t tx_frame_history_tx_count[FPGA_TX_FRAME_HISTORY];
     volatile uint8_t  tx_frame_history_head;

--- a/firmware/src/drivers/fpga_meter_plan.c
+++ b/firmware/src/drivers/fpga_meter_plan.c
@@ -3,19 +3,43 @@
 #define FPGA_METER_STOCK_WORD_BASE 0x0500u
 
 /*
- * Stock source of truth:
- * reverse_engineering/analysis_v120/meter_mode_command_table_2026_06_05.md
- * records the eight recovered selector low bytes below. The open firmware has
- * eleven UI submodes, so this module maps local UI policy onto those eight
- * hardware selector slots; it does not claim that stock has eleven independent
- * analog frontend modes. In particular, DC mA/DC A share stock slot 2,
- * AC mA/local AC A share stock slot 3, and capacitance/temperature share stock
- * slot 5 until a stock writer or bench trace proves a narrower selector. If a
- * future live case is surprising, keep that boundary here: do not invent a new
- * 0x05xx selector for the local split without binary stock evidence.
+ * The word the meter SoC obeys for each local submode. MEASURED, not decompiled
+ * (issue #15): a logger patched into stock V1.2.0 recorded every TX frame while
+ * the stock meter menu was walked, one word per function, no pairs, no GPIO
+ * writes (unit #2, 2026-09-07); 0x0B and 0x0C replicated on unit #1 (EXP-25,
+ * EXP-27). The AC/DC toggle inside a stock function is its own word: DC Voltage
+ * 0x0C -> AC Voltage 0x0D, Continuity 0x17 -> Diode 0x0E, small DC current
+ * 0x11 -> small AC current 0x16, large DC current 0x10 -> large AC current
+ * 0x15. So every local submode owns a distinct selector, and nothing here has
+ * to share a slot any more.
+ *
+ * The eight-byte table `14 0c 17 0b 0a 12 11 10` at stock 0x080BB3FC (pinned
+ * by scripts/test_stock_meter_literals.py) is real, but it is stock's MENU
+ * ORDER -- Auto, DC Voltage, Continuity, Resistance, Capacitance, Temperature,
+ * small DC current, large DC current -- not a mode index. Indexing it by a
+ * mode number is how this module selected Auto for "DCV", Continuity for the
+ * DC currents, Resistance for the AC currents, Capacitance for "Resistance",
+ * the currents for Continuity/Diode and Temperature for "Capacitance": ten of
+ * eleven submodes wrong, invisible for five months because the frames also
+ * carried the wrong header and the SoC discarded every one of them.
+ *
+ * Words the SoC accepts that have no local submode: 0x14 Auto (the SoC's own
+ * autorange-everything function), 0x13 LIVE (the NCV screen; its frame is the
+ * seven-segment text "L1uE", not a value), 0x0F (accepted, never sent by stock).
  */
-static const uint8_t stock_meter_cmd_low[FPGA_METER_STOCK_MODE_COUNT] = {
-    0x14, 0x0C, 0x17, 0x0B, 0x0A, 0x12, 0x11, 0x10
+static const uint8_t
+stock_meter_word_low_for_submode[FPGA_METER_LOCAL_SUBMODE_COUNT] = {
+    0x0C, /*  0 DC voltage       */
+    0x0D, /*  1 AC voltage       */
+    0x11, /*  2 DC current, mA   */
+    0x10, /*  3 DC current, A    */
+    0x16, /*  4 AC current, mA   */
+    0x15, /*  5 AC current, A    */
+    0x0B, /*  6 resistance       */
+    0x17, /*  7 continuity       */
+    0x0E, /*  8 diode            */
+    0x0A, /*  9 capacitance      */
+    0x12, /* 10 temperature      */
 };
 
 /*
@@ -131,84 +155,45 @@ bool fpga_meter_logical_function_is_unresolved(uint8_t function)
            !fpga_meter_logical_function_is_supported(function);
 }
 
+/*
+ * `stock_mode` is the FORMATTER FAMILY of a submode: the case index the stock
+ * display formatter (meter_data.c, meter_stock_fsm_apply) and the local mux
+ * projection below run on. It used to double as the index into the wire-word
+ * table, which is where the wrong selectors came from. It no longer touches
+ * the wire: the word the SoC hears is stock_meter_word_low_for_submode[],
+ * one per submode, and the pairs that share a formatter family here (DC mA /
+ * DC A, AC mA / AC A, capacitance / temperature) do so only because stock
+ * formats them alike, not because the SoC cannot tell them apart.
+ */
 uint8_t fpga_meter_stock_mode_for_submode(uint8_t submode)
 {
     switch (submode) {
     case 0: return 0; /* DCV */
     case 1: return 1; /* ACV */
     case 2: /* DC mA */
-    case 3: /* DC A */
+    case 3: /* DC A  -- same formatter family, different wire word */
         return 2;
     case 4: /* AC mA */
-    case 5: /* Local AC A policy over the recovered ACA slot. */
+    case 5: /* AC A  -- same formatter family, different wire word */
         return 3;
     case 6: return 4; /* Resistance */
     case 7: return 6; /* Continuity */
     case 8: return 7; /* Diode */
     case 9:  /* Capacitance */
-    case 10: /* Local temp split on the recovered extended stock slot. */
+    case 10: /* Temperature -- same formatter family, different wire word */
         return 5;
     default:
         return FPGA_METER_INVALID_STOCK_MODE;
     }
 }
 
-uint8_t fpga_meter_stock_cmd_low_for_mode(uint8_t stock_mode)
-{
-    if (stock_mode >= FPGA_METER_STOCK_MODE_COUNT) {
-        return 0;
-    }
-    return stock_meter_cmd_low[stock_mode];
-}
-
 uint16_t fpga_meter_stock_cmd_word_for_submode(uint8_t submode)
 {
-    uint8_t stock_mode = fpga_meter_stock_mode_for_submode(submode);
-    if (stock_mode >= FPGA_METER_STOCK_MODE_COUNT) {
+    if (!fpga_meter_submode_is_valid(submode)) {
         return FPGA_METER_INVALID_SELECTOR_WORD;
     }
     return (uint16_t)(FPGA_METER_STOCK_WORD_BASE |
-                      fpga_meter_stock_cmd_low_for_mode(stock_mode));
-}
-
-bool fpga_meter_stock_apply_cmd_word_for_submode(uint8_t submode, uint16_t *word)
-{
-    uint8_t stock_mode = fpga_meter_stock_mode_for_submode(submode);
-    uint8_t low;
-
-    /*
-     * Stock V1.2.0 dynamic raw-word helper boundary:
-     *   0x08006120 gates and masks the selector-side state,
-     *   0x08006194 / 0x0800626A choose low-byte pairs, and
-     *   0x08006288 emits 0x0500 | low through the dvom_TX raw-word path.
-     *
-     * Recovered apply pairs are ACV 0x0C/0x0D, DCA 0x17/0x0E,
-     * continuity 0x11/0x16, and diode 0x10/0x15.  There is no recovered
-     * apply pair yet for DCV, ACA, resistance, capacitance, temperature, or
-     * microamp modes; those must not be filled from the parsed numeric value,
-     * one-point live observations, or local range guesses.
-     */
-    switch (stock_mode) {
-    case 1:
-        low = 0x0D;
-        break;
-    case 2:
-        low = 0x0E;
-        break;
-    case 6:
-        low = 0x16;
-        break;
-    case 7:
-        low = 0x15;
-        break;
-    default:
-        return false;
-    }
-
-    if (word != 0) {
-        *word = (uint16_t)(FPGA_METER_STOCK_WORD_BASE | low);
-    }
-    return true;
+                      stock_meter_word_low_for_submode[submode]);
 }
 
 fpga_meter_frame_family_t fpga_meter_frame_family_for_submode(uint8_t submode)
@@ -304,7 +289,9 @@ fpga_meter_transition_plan_t fpga_meter_transition_plan_for_submode(uint8_t subm
      * 0x0800BCA6 as queuing byte commands 0x00 then 0x2C before the common
      * send tail. That is not a raw 0x052C selector and not a numeric range
      * correction; it is the recovered byte-dispatch state that arms the
-     * continuity/diode family before the raw selector/apply pair below.
+     * continuity/diode family before the raw selector below. On the wire it
+     * goes out UNOBEYED (00 00 header, see fpga.c): with the AA 55 header
+     * live, only the selector word is a command to the SoC.
      */
     plan.has_command_bank_prefix = (submode == 7 || submode == 8);
     plan.command_bank_first = plan.has_command_bank_prefix ? 0x00u : 0x00u;
@@ -317,14 +304,23 @@ fpga_meter_transition_plan_t fpga_meter_transition_plan_for_submode(uint8_t subm
      * emits 0x0508 before 0x0514, while the earlier open firmware only sent
      * 0x0514 on normal DCV transitions. Low-DCV live failures are
      * producer-frame faults, so re-materialize this stock basic configure word
-     * for DCV without treating it as a numeric correction or as one of the
-     * dynamic selector/apply pairs.
+     * for DCV without treating it as a numeric correction. Like the bank
+     * prefix it is sent UNOBEYED: measured on unit #2, an obeyed 0x0508 is
+     * echoed and changes nothing visible, so it stays traffic, not a command.
      */
     plan.has_config_word = submode == 0;
     plan.config_word = plan.has_config_word ? FPGA_METER_CONFIGURE_WORD : 0;
     plan.selector_word = fpga_meter_stock_cmd_word_for_submode(submode);
-    plan.has_apply_word =
-        fpga_meter_stock_apply_cmd_word_for_submode(submode, &plan.apply_word);
+    /*
+     * No apply word. The four "selector/apply pairs" this used to carry
+     * (0x0C/0x0D, 0x17/0x0E, 0x11/0x16, 0x10/0x15) are stock's AC/DC toggle:
+     * the second word of each pair is the primary selector of another local
+     * submode (ACV, diode, AC mA, AC A) and now goes out as such. The fields
+     * stay in the struct because the transition history and the shell print
+     * them; they read 0.
+     */
+    plan.has_apply_word = false;
+    plan.apply_word = 0;
     plan.has_probe_detect = true;
     plan.start_word = FPGA_METER_START_WORD;
     if (plan.stock_mode >= FPGA_METER_STOCK_MODE_COUNT) {

--- a/firmware/src/drivers/fpga_meter_plan.h
+++ b/firmware/src/drivers/fpga_meter_plan.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 
 #define FPGA_METER_LOCAL_SUBMODE_COUNT 11u
-#define FPGA_METER_STOCK_MODE_COUNT    8u
+#define FPGA_METER_STOCK_MODE_COUNT    8u   /* formatter families, not wire words */
 #define FPGA_METER_LOGICAL_FUNCTION_COUNT 13u
 #define FPGA_METER_TRANSITION_DISCARD_FRAMES 2u
 #define FPGA_METER_TRANSITION_SETTLE_MS      20u
@@ -88,9 +88,7 @@ bool fpga_meter_logical_function_is_supported(uint8_t function);
 bool fpga_meter_logical_function_is_unresolved(uint8_t function);
 uint8_t fpga_meter_submode_for_logical_function(uint8_t function);
 uint8_t fpga_meter_stock_mode_for_submode(uint8_t submode);
-uint8_t fpga_meter_stock_cmd_low_for_mode(uint8_t stock_mode);
 uint16_t fpga_meter_stock_cmd_word_for_submode(uint8_t submode);
-bool fpga_meter_stock_apply_cmd_word_for_submode(uint8_t submode, uint16_t *word);
 fpga_meter_frame_family_t fpga_meter_frame_family_for_submode(uint8_t submode);
 bool fpga_meter_frame_family_is_recovered(uint8_t family);
 bool fpga_meter_frame_family_has_stock_marker(uint8_t family);

--- a/firmware/src/drivers/usb_debug.c
+++ b/firmware/src/drivers/usb_debug.c
@@ -2289,7 +2289,8 @@ static void cmd_meter_hdr(const char *args)
     usb_debug_printf(
         "meter TX header: %s  (frame[0]=%02X frame[1]=%02X)\r\n"
         "  tx_count=%u rx_bytes=%u data_frames=%u\r\n"
-        "  echo_start=%u echo_hdr=%u echo_valid=%u echo_bad=%u echo_frames=%u\r\n",
+        "  echo_start=%u echo_hdr=%u echo_valid=%u echo_bad=%u echo_frames=%u\r\n"
+        "  transition: wake_ms=%u tries=%u ok=%u | unconfirmed=%u wake_timeouts=%u\r\n",
         aa55 ? "AA 55 (default)" : "00 00 (legacy, negative control)",
         aa55 ? 0xAA : 0x00, aa55 ? 0x55 : 0x00,
         (unsigned)fpga.tx_count, (unsigned)fpga.rx_byte_count,
@@ -2298,7 +2299,12 @@ static void cmd_meter_hdr(const char *args)
         (unsigned)fpga.rx_sync_echo_header_count,
         (unsigned)fpga.rx_echo_valid_count,
         (unsigned)fpga.rx_echo_bad_count,
-        (unsigned)fpga.echo_count);
+        (unsigned)fpga.echo_count,
+        (unsigned)fpga.meter_soc_wake_ms,
+        (unsigned)fpga.meter_selector_attempts,
+        (unsigned)fpga.meter_selector_confirmed,
+        (unsigned)fpga.meter_selector_unconfirmed_total,
+        (unsigned)fpga.meter_soc_wake_timeouts);
 }
 
 /* `fpga rearm [on|off]` — stock's post-read re-arm write (reg 0x01 <- rate idx).

--- a/firmware/src/drivers/usb_debug.c
+++ b/firmware/src/drivers/usb_debug.c
@@ -550,9 +550,13 @@ static void fpga_stock_diag_print(void)
     usb_send_str("\r\n");
 }
 
+/* Shell replays of stock's scope word stream (`fpga scope entry/freq/trigger`).
+ * Unobeyed, like fpga.c's own scope sequences: these words have always gone
+ * out 00 00, and what the meter SoC does with an AA 55 frame whose high byte
+ * is a scope parameter has never been measured. */
 static bool fpga_send_cmd_timed(uint8_t cmd_hi, uint8_t cmd_lo, uint32_t delay_ms)
 {
-    BaseType_t ok = fpga_send_cmd(cmd_hi, cmd_lo);
+    BaseType_t ok = fpga_send_cmd_unobeyed(cmd_hi, cmd_lo);
     if (ok != pdTRUE) {
         usb_debug_printf("Queue full at %02X %02X\r\n", cmd_hi, cmd_lo);
         return false;
@@ -2258,9 +2262,11 @@ static void cmd_fpga_usart(const char *args)
 }
 
 /* `meter hdr [on|off]` — EXP-25 (issue #15). A/B the meter TX frame header
- * between 00 00 (what this project has always sent) and AA 55 (what Stlkv
- * measured the meter SoC requires). Prints the echo ladder every time, so the
- * A/B is one command and the numbers are on the same screen as the setting.
+ * between AA 55 (the default since the word table was corrected; what the
+ * meter SoC requires, measured on two units) and 00 00 (what this project sent
+ * before 2026-09-12, kept as the negative control: a transition under 00 00
+ * must produce zero echoes). Prints the echo ladder every time, so the A/B is
+ * one command and the numbers are on the same screen as the setting.
  *
  * Read the ladder from the bottom up when it stays at zero:
  *   rx_bytes    moving => the RX ISR runs at all
@@ -2284,7 +2290,7 @@ static void cmd_meter_hdr(const char *args)
         "meter TX header: %s  (frame[0]=%02X frame[1]=%02X)\r\n"
         "  tx_count=%u rx_bytes=%u data_frames=%u\r\n"
         "  echo_start=%u echo_hdr=%u echo_valid=%u echo_bad=%u echo_frames=%u\r\n",
-        aa55 ? "AA 55" : "00 00 (baseline)",
+        aa55 ? "AA 55 (default)" : "00 00 (legacy, negative control)",
         aa55 ? 0xAA : 0x00, aa55 ? 0x55 : 0x00,
         (unsigned)fpga.tx_count, (unsigned)fpga.rx_byte_count,
         (unsigned)fpga.frame_count,
@@ -4820,7 +4826,9 @@ static void cmd_meter_mux_arms(const char *args)
     }
 
     vTaskDelay(pdMS_TO_TICKS(settle_ms));
-    (void)fpga_send_cmd(0x05, FPGA_CMD_METER_START);
+    /* Unobeyed: obeyed 0x0509 moves the SoC's display state, and this trace
+     * is about the relays, not about commanding the meter. */
+    (void)fpga_send_cmd_unobeyed(0x05, FPGA_CMD_METER_START);
     vTaskDelay(pdMS_TO_TICKS(350));
 
     usb_send_str("=== DMM Mux Arms Trace ===\r\n");
@@ -4860,7 +4868,9 @@ static void cmd_meter_boot_sequence(const char *args)
     }
 
     vTaskDelay(pdMS_TO_TICKS(settle_ms));
-    (void)fpga_send_cmd(0x05, FPGA_CMD_METER_START);
+    /* Unobeyed: obeyed 0x0509 moves the SoC's display state, and this trace
+     * is about the relays, not about commanding the meter. */
+    (void)fpga_send_cmd_unobeyed(0x05, FPGA_CMD_METER_START);
     vTaskDelay(pdMS_TO_TICKS(350));
 
     usb_send_str("=== DMM Boot-Order Trace ===\r\n");
@@ -4920,7 +4930,9 @@ static void cmd_meter_pc11_timing(const char *args)
     }
 
     vTaskDelay(pdMS_TO_TICKS(high_ms));
-    (void)fpga_send_cmd(0x05, FPGA_CMD_METER_START);
+    /* Unobeyed: obeyed 0x0509 moves the SoC's display state, and this trace
+     * is about the relays, not about commanding the meter. */
+    (void)fpga_send_cmd_unobeyed(0x05, FPGA_CMD_METER_START);
     vTaskDelay(pdMS_TO_TICKS(350));
 
     usb_send_str("=== DMM PC11 Timing Trace ===\r\n");
@@ -5381,9 +5393,11 @@ static void cmd_spi3_acqtest(void)
 
     /* --- Test 3: USART2 scope-arm then SPI3 read --- */
     usb_send_str("\r\n-- T3: USART2 arm (0x20,0x21) → SPI3 read --\r\n");
-    fpga_send_cmd(0x00, 0x20);  /* Scope timebase cmd */
+    /* Unobeyed (00 00): the SoC's reaction to AA 55 frames with a 0x00 high
+     * byte is unmeasured, and this test is about SPI3, not the meter. */
+    fpga_send_cmd_unobeyed(0x00, 0x20);  /* Scope timebase cmd */
     vTaskDelay(pdMS_TO_TICKS(30));
-    fpga_send_cmd(0x00, 0x21);  /* Scope trigger mode cmd */
+    fpga_send_cmd_unobeyed(0x00, 0x21);  /* Scope trigger mode cmd */
     vTaskDelay(pdMS_TO_TICKS(30));
 
     usb_debug_printf("PC0 after arm: %d\r\n", (GPIOC->idt & (1 << 0)) ? 1 : 0);
@@ -5401,18 +5415,18 @@ static void cmd_spi3_acqtest(void)
     /* --- Test 4: Full stock scope entry (0x01..0x08, 0x0B..0x11, 0x20, 0x21) --- */
     usb_send_str("\r\n-- T4: Full scope entry → SPI3 read --\r\n");
     /* Reset sequence */
-    fpga_send_cmd(0x00, 0x01);  vTaskDelay(pdMS_TO_TICKS(10));
-    fpga_send_cmd(0x00, 0x02);  vTaskDelay(pdMS_TO_TICKS(10));
-    fpga_send_cmd(0x00, 0x03);  vTaskDelay(pdMS_TO_TICKS(10));
-    fpga_send_cmd(0x00, 0x0B);  vTaskDelay(pdMS_TO_TICKS(10));  /* CH1 gain */
-    fpga_send_cmd(0x00, 0x0C);  vTaskDelay(pdMS_TO_TICKS(10));  /* CH1 offset */
-    fpga_send_cmd(0x00, 0x0D);  vTaskDelay(pdMS_TO_TICKS(10));  /* CH2 gain */
-    fpga_send_cmd(0x00, 0x0E);  vTaskDelay(pdMS_TO_TICKS(10));  /* CH2 offset */
-    fpga_send_cmd(0x00, 0x0F);  vTaskDelay(pdMS_TO_TICKS(10));  /* Coupling */
-    fpga_send_cmd(0x00, 0x10);  vTaskDelay(pdMS_TO_TICKS(10));  /* Trigger */
-    fpga_send_cmd(0x00, 0x11);  vTaskDelay(pdMS_TO_TICKS(10));  /* Timebase */
-    fpga_send_cmd(0x00, 0x20);  vTaskDelay(pdMS_TO_TICKS(10));  /* Acq mode */
-    fpga_send_cmd(0x00, 0x21);  vTaskDelay(pdMS_TO_TICKS(50));  /* Trigger arm */
+    fpga_send_cmd_unobeyed(0x00, 0x01);  vTaskDelay(pdMS_TO_TICKS(10));
+    fpga_send_cmd_unobeyed(0x00, 0x02);  vTaskDelay(pdMS_TO_TICKS(10));
+    fpga_send_cmd_unobeyed(0x00, 0x03);  vTaskDelay(pdMS_TO_TICKS(10));
+    fpga_send_cmd_unobeyed(0x00, 0x0B);  vTaskDelay(pdMS_TO_TICKS(10));  /* CH1 gain */
+    fpga_send_cmd_unobeyed(0x00, 0x0C);  vTaskDelay(pdMS_TO_TICKS(10));  /* CH1 offset */
+    fpga_send_cmd_unobeyed(0x00, 0x0D);  vTaskDelay(pdMS_TO_TICKS(10));  /* CH2 gain */
+    fpga_send_cmd_unobeyed(0x00, 0x0E);  vTaskDelay(pdMS_TO_TICKS(10));  /* CH2 offset */
+    fpga_send_cmd_unobeyed(0x00, 0x0F);  vTaskDelay(pdMS_TO_TICKS(10));  /* Coupling */
+    fpga_send_cmd_unobeyed(0x00, 0x10);  vTaskDelay(pdMS_TO_TICKS(10));  /* Trigger */
+    fpga_send_cmd_unobeyed(0x00, 0x11);  vTaskDelay(pdMS_TO_TICKS(10));  /* Timebase */
+    fpga_send_cmd_unobeyed(0x00, 0x20);  vTaskDelay(pdMS_TO_TICKS(10));  /* Acq mode */
+    fpga_send_cmd_unobeyed(0x00, 0x21);  vTaskDelay(pdMS_TO_TICKS(50));  /* Trigger arm */
 
     usb_debug_printf("PC0 after full entry: %d\r\n", (GPIOC->idt & (1 << 0)) ? 1 : 0);
 
@@ -7107,7 +7121,7 @@ static const shell_cmd_t shell_cmds[] = {
     CMD_A("fpga rearm", cmd_fpga_rearm, 0,
           "fpga rearm [on|off]             Stock post-read re-arm (reg01) A/B toggle\r\n"),
     CMD_A("meter hdr", cmd_meter_hdr, 0,
-          "meter hdr [on|off]              Meter TX header 00 00 vs AA 55 (EXP-25) + echo ladder\r\n"),
+          "meter hdr [on|off]              Meter TX header AA 55 (default) vs 00 00 (EXP-25) + echo ladder\r\n"),
     CMD_A("fpga rate", cmd_fpga_rate, 0,
           "fpga rate [hexidx]              reg-0x01 rate index the re-arm rewrites\r\n"),
     CMD_V("fpga scope reinit", cmd_fpga_scope_reinit, SC_EXACT,

--- a/firmware/tests/test_fpga_meter_plan.c
+++ b/firmware/tests/test_fpga_meter_plan.c
@@ -55,16 +55,28 @@ static void expect_mux_state(const char *label,
     EXPECT_EQ_U8(name, got->pa6, want->pa6);
 }
 
-static void test_stock_table_bytes(void)
+static void test_measured_word_map_is_one_distinct_word_per_submode(void)
 {
-    static const uint8_t expected[FPGA_METER_STOCK_MODE_COUNT] = {
-        0x14, 0x0C, 0x17, 0x0B, 0x0A, 0x12, 0x11, 0x10
-    };
+    /*
+     * The meter SoC's word map, measured with a logger inside stock V1.2.0
+     * (issue #15). Every submode owns a distinct word; none of them is Auto
+     * (0x14), LIVE (0x13) or the never-sent 0x0F; all sit in the accepted
+     * 0x0A..0x17 range.
+     */
+    uint32_t seen = 0;
 
-    for (uint8_t i = 0; i < FPGA_METER_STOCK_MODE_COUNT; i++) {
-        char name[32];
-        snprintf(name, sizeof(name), "stock low %u", (unsigned)i);
-        EXPECT_EQ_U8(name, fpga_meter_stock_cmd_low_for_mode(i), expected[i]);
+    for (uint8_t i = 0; i < FPGA_METER_LOCAL_SUBMODE_COUNT; i++) {
+        char name[48];
+        uint16_t word = fpga_meter_stock_cmd_word_for_submode(i);
+        uint8_t low = (uint8_t)(word & 0xFFU);
+
+        snprintf(name, sizeof(name), "submode %u word in range", (unsigned)i);
+        EXPECT_EQ_U8(name, (low >= 0x0A && low <= 0x17) ? 1U : 0U, 1U);
+        snprintf(name, sizeof(name), "submode %u word is not Auto/LIVE/0F", (unsigned)i);
+        EXPECT_EQ_U8(name, (low == 0x14 || low == 0x13 || low == 0x0F) ? 1U : 0U, 0U);
+        snprintf(name, sizeof(name), "submode %u word is distinct", (unsigned)i);
+        EXPECT_EQ_U8(name, (seen & (1UL << low)) ? 1U : 0U, 0U);
+        seen |= (1UL << low);
     }
 }
 
@@ -148,8 +160,8 @@ static void test_logical_function_capability_matrix_covers_all_dmm_modes(void)
 static void test_wire_words_are_raw_05_family(void)
 {
     static const uint16_t expected_words[FPGA_METER_LOCAL_SUBMODE_COUNT] = {
-        0x0514, 0x050C, 0x0517, 0x0517, 0x050B,
-        0x050B, 0x050A, 0x0511, 0x0510, 0x0512,
+        0x050C, 0x050D, 0x0511, 0x0510, 0x0516,
+        0x0515, 0x050B, 0x0517, 0x050E, 0x050A,
         0x0512
     };
 
@@ -162,53 +174,45 @@ static void test_wire_words_are_raw_05_family(void)
     }
 }
 
-static void test_stock_apply_words_for_runtime_family_switch(void)
+static void test_stock_toggle_words_are_selectors_not_apply_words(void)
 {
     /*
-     * Stock dynamic raw-word helper at 0x08006120 chooses only these
-     * selector/apply low-byte pairs for runtime family-side switching:
-     * ACV 0x0C/0x0D, DCA 0x17/0x0E, continuity 0x11/0x16, diode 0x10/0x15.
-     * Keep the local apply table as a subset of that recovered pair set; do
-     * not add an apply word for a surprising range without new stock xrefs.
+     * Stock's decompile showed four low-byte pairs (0x0C/0x0D, 0x17/0x0E,
+     * 0x11/0x16, 0x10/0x15) and this module used to send the second of each
+     * as an "apply" word after the first. Measured with stock's own TX stream
+     * (issue #15), the second word is what stock sends when the AC/DC toggle
+     * inside a function is pressed: ACV, Diode, AC mA, AC A. So each is the
+     * primary selector of its own local submode, and no submode has an apply
+     * word any more.
      */
-    static const uint16_t expected_apply[FPGA_METER_LOCAL_SUBMODE_COUNT] = {
-        0x0000, 0x050D, 0x050E, 0x050E, 0x0000,
-        0x0000, 0x0000, 0x0516, 0x0515, 0x0000,
-        0x0000
-    };
-    static const uint16_t stock_dynamic_apply_words[] = {
-        0x050D, 0x050E, 0x0516, 0x0515
+    static const struct {
+        uint16_t word;
+        uint8_t  submode;
+    } toggle_words[] = {
+        { 0x050D, 1 }, /* DC Voltage -> AC Voltage */
+        { 0x050E, 8 }, /* Continuity -> Diode */
+        { 0x0516, 4 }, /* small DC current -> small AC current */
+        { 0x0515, 5 }, /* large DC current -> large AC current */
     };
 
     for (uint8_t i = 0; i < FPGA_METER_LOCAL_SUBMODE_COUNT; i++) {
-        char name[32];
-        uint16_t word = 0xAAAA;
-        bool have_word = fpga_meter_stock_apply_cmd_word_for_submode(i, &word);
+        char name[48];
+        fpga_meter_transition_plan_t plan =
+            fpga_meter_transition_plan_for_submode(i);
 
-        snprintf(name, sizeof(name), "apply exists %u", (unsigned)i);
-        EXPECT_EQ_U8(name, have_word ? 1U : 0U,
-                     expected_apply[i] != 0 ? 1U : 0U);
-        if (expected_apply[i] != 0) {
-            snprintf(name, sizeof(name), "apply word %u", (unsigned)i);
-            EXPECT_EQ_U16(name, word, expected_apply[i]);
-            EXPECT_EQ_U8("apply raw family", (uint8_t)(word >> 8), 0x05);
-            {
-                uint8_t found = 0;
-                for (uint8_t j = 0;
-                     j < sizeof(stock_dynamic_apply_words) /
-                         sizeof(stock_dynamic_apply_words[0]);
-                     j++) {
-                    if (word == stock_dynamic_apply_words[j]) {
-                        found = 1;
-                    }
-                }
-                snprintf(name, sizeof(name), "apply stock pair %u", (unsigned)i);
-                EXPECT_EQ_U8(name, found, 1U);
-            }
-        } else {
-            snprintf(name, sizeof(name), "apply untouched %u", (unsigned)i);
-            EXPECT_EQ_U16(name, word, 0xAAAA);
-        }
+        snprintf(name, sizeof(name), "no apply word %u", (unsigned)i);
+        EXPECT_EQ_U8(name, plan.has_apply_word ? 1U : 0U, 0U);
+        snprintf(name, sizeof(name), "apply word zero %u", (unsigned)i);
+        EXPECT_EQ_U16(name, plan.apply_word, 0x0000U);
+    }
+
+    for (unsigned i = 0; i < sizeof(toggle_words) / sizeof(toggle_words[0]); i++) {
+        char name[48];
+        snprintf(name, sizeof(name), "toggle word 0x%04X is a selector",
+                 (unsigned)toggle_words[i].word);
+        EXPECT_EQ_U16(name,
+                      fpga_meter_stock_cmd_word_for_submode(toggle_words[i].submode),
+                      toggle_words[i].word);
     }
 }
 
@@ -231,13 +235,13 @@ static void test_transition_plan_covers_mux_family_and_settle_policy(void)
         FPGA_METER_FRAME_FAMILY_EXTENDED,
     };
     static const uint16_t expected_selector[FPGA_METER_LOCAL_SUBMODE_COUNT] = {
-        0x0514, 0x050C, 0x0517, 0x0517, 0x050B,
-        0x050B, 0x050A, 0x0511, 0x0510, 0x0512,
+        0x050C, 0x050D, 0x0511, 0x0510, 0x0516,
+        0x0515, 0x050B, 0x0517, 0x050E, 0x050A,
         0x0512
     };
     static const uint16_t expected_apply[FPGA_METER_LOCAL_SUBMODE_COUNT] = {
-        0x0000, 0x050D, 0x050E, 0x050E, 0x0000,
-        0x0000, 0x0000, 0x0516, 0x0515, 0x0000,
+        0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
         0x0000
     };
     static const uint16_t expected_config[FPGA_METER_LOCAL_SUBMODE_COUNT] = {
@@ -567,8 +571,15 @@ static void test_frame_family_marker_visibility_documents_observed_gaps(void)
                  0U);
 }
 
-static void test_local_splits_do_not_invent_extra_stock_selectors(void)
+static void test_local_splits_share_formatter_family_not_wire_word(void)
 {
+    /*
+     * These pairs share a stock formatter family (and therefore the local mux
+     * projection), but each half owns its own selector word: stock's meter
+     * menu has separate entries for the two currents, and capacitance and
+     * temperature are 0x0A and 0x12. Sharing the word here is what made the
+     * old table select Temperature for "Capacitance".
+     */
     static const struct {
         uint8_t a;
         uint8_t b;
@@ -588,8 +599,8 @@ static void test_local_splits_do_not_invent_extra_stock_selectors(void)
 
         snprintf(name, sizeof(name), "%s stock slot", shared_slots[i].label);
         EXPECT_EQ_U8(name, a.stock_mode, b.stock_mode);
-        snprintf(name, sizeof(name), "%s selector", shared_slots[i].label);
-        EXPECT_EQ_U16(name, a.selector_word, b.selector_word);
+        snprintf(name, sizeof(name), "%s selectors differ", shared_slots[i].label);
+        EXPECT_EQ_U8(name, a.selector_word != b.selector_word ? 1U : 0U, 1U);
         snprintf(name, sizeof(name), "%s Port C/E mux", shared_slots[i].label);
         EXPECT_EQ_U8(name, a.portc_porte_mux, b.portc_porte_mux);
         snprintf(name, sizeof(name), "%s Port A/B mux", shared_slots[i].label);
@@ -645,8 +656,6 @@ static void test_fallbacks(void)
         fpga_meter_transition_plan_for_submode(99);
     fpga_meter_mux_gpio_state_t state = { 0 };
 
-    EXPECT_EQ_U8("bad stock mode is invalid",
-                 fpga_meter_stock_cmd_low_for_mode(99), 0);
     EXPECT_EQ_U8("bad submode valid",
                  fpga_meter_submode_is_valid(99) ? 1U : 0U, 0U);
     EXPECT_EQ_U8("good submode valid",
@@ -657,8 +666,6 @@ static void test_fallbacks(void)
     EXPECT_EQ_U16("bad submode word",
                   fpga_meter_stock_cmd_word_for_submode(99),
                   FPGA_METER_INVALID_SELECTOR_WORD);
-    EXPECT_EQ_U8("bad submode no apply word",
-                 fpga_meter_stock_apply_cmd_word_for_submode(99, NULL) ? 1U : 0U, 0U);
     EXPECT_EQ_U8("bad plan stock", plan.stock_mode,
                  FPGA_METER_INVALID_STOCK_MODE);
     EXPECT_EQ_U8("bad plan mux", plan.mux_index,
@@ -758,11 +765,11 @@ static void test_every_submode_transition_drains_before_accepting_frames(void)
 
 int main(void)
 {
-    test_stock_table_bytes();
+    test_measured_word_map_is_one_distinct_word_per_submode();
     test_local_submode_mapping();
     test_logical_function_capability_matrix_covers_all_dmm_modes();
     test_wire_words_are_raw_05_family();
-    test_stock_apply_words_for_runtime_family_switch();
+    test_stock_toggle_words_are_selectors_not_apply_words();
     test_transition_plan_covers_mux_family_and_settle_policy();
     test_mux_gpio_state_matches_stock_projection_for_every_submode();
     test_mux_writer_stock_arm_truth_table_covers_all_10_switch_arms();
@@ -770,7 +777,7 @@ int main(void)
     test_state_machine_contract_is_exhaustive();
     test_frame_family_mismatch_policy_matrix_is_exhaustive();
     test_frame_family_marker_visibility_documents_observed_gaps();
-    test_local_splits_do_not_invent_extra_stock_selectors();
+    test_local_splits_share_formatter_family_not_wire_word();
     test_local_splits_share_mux_gpio_state();
     test_fallbacks();
     test_rx_frame_gate_preserves_discard_budget_while_busy();

--- a/scripts/validate_dmm_goal.py
+++ b/scripts/validate_dmm_goal.py
@@ -476,7 +476,9 @@ def verify_meter_aux_afe_pin_policy() -> dict[str, Any]:
         raise GateError("could not locate fpga_init body")
     init_body = text[init_start:init_end]
     boot_frontend = init_body.find("fpga_set_meter_frontend_for_submode(0);")
-    boot_activate = init_body.find("usart2_send_cmd(0x05, 0x08);")
+    # The activation block is sent unobeyed since the AA 55 header shipped
+    # (0x0A is Capacitance, 0x14 is Auto); the order it guards is unchanged.
+    boot_activate = init_body.find("usart2_send_cmd_ex(0x05, 0x08, false);")
     bad_boot_order = (
         boot_frontend < 0 or boot_activate < 0 or boot_frontend > boot_activate
     )
@@ -832,7 +834,7 @@ def verify_transition_plan_property_contract() -> dict[str, Any]:
     text = (REPO / rel).read_text(encoding="utf-8", errors="replace")
     required_tests = [
         "transition_plan_covers_mux_family_and_settle_policy",
-        "stock_apply_words_for_runtime_family_switch",
+        "stock_toggle_words_are_selectors_not_apply_words",
         "mux_gpio_state_matches_stock_projection_for_every_submode",
         "mux_writer_stock_arm_truth_table_covers_all_10_switch_arms",
         "transition_settle_discard_policy_is_explicit_for_every_submode",
@@ -840,7 +842,7 @@ def verify_transition_plan_property_contract() -> dict[str, Any]:
         "frame_family_mismatch_policy_matrix_is_exhaustive",
         "frame_family_marker_visibility_documents_observed_gaps",
         "logical_function_capability_matrix_covers_all_dmm_modes",
-        "local_splits_do_not_invent_extra_stock_selectors",
+        "local_splits_share_formatter_family_not_wire_word",
         "local_splits_share_mux_gpio_state",
         "fallbacks",
         "rx_frame_gate_preserves_discard_budget_while_busy",
@@ -850,17 +852,19 @@ def verify_transition_plan_property_contract() -> dict[str, Any]:
         "local stock-mode mapping preserves recovered shared slots":
             r"static const uint8_t expected_stock_mode\[FPGA_METER_LOCAL_SUBMODE_COUNT\]\s*=\s*"
             r"\{\s*0,\s*1,\s*2,\s*2,\s*3,\s*3,\s*4,\s*6,\s*7,\s*5,\s*5\s*\};",
-        "local selector words preserve recovered stock command table":
+        # The measured word map (issue #15): one distinct word per submode,
+        # recorded from stock V1.2.0's own TX stream, not from the decompile.
+        "local selector words follow the measured stock word map":
             r"static const uint16_t expected_words\[FPGA_METER_LOCAL_SUBMODE_COUNT\]\s*=\s*"
-            r"\{\s*0x0514,\s*0x050C,\s*0x0517,\s*0x0517,\s*0x050B,\s*"
-            r"0x050B,\s*0x050A,\s*0x0511,\s*0x0510,\s*0x0512,\s*0x0512\s*\};",
-        "runtime apply words stay limited to recovered helper slots":
+            r"\{\s*0x050C,\s*0x050D,\s*0x0511,\s*0x0510,\s*0x0516,\s*"
+            r"0x0515,\s*0x050B,\s*0x0517,\s*0x050E,\s*0x050A,\s*0x0512\s*\};",
+        "no submode carries an apply word":
             r"static const uint16_t expected_apply\[FPGA_METER_LOCAL_SUBMODE_COUNT\]\s*=\s*"
-            r"\{\s*0x0000,\s*0x050D,\s*0x050E,\s*0x050E,\s*0x0000,\s*"
-            r"0x0000,\s*0x0000,\s*0x0516,\s*0x0515,\s*0x0000,\s*0x0000\s*\};",
-        "runtime apply words are subset of stock dynamic helper pairs":
-            r"static const uint16_t stock_dynamic_apply_words\[\]\s*=\s*"
-            r"\{\s*0x050D,\s*0x050E,\s*0x0516,\s*0x0515\s*\};",
+            r"\{\s*0x0000,\s*0x0000,\s*0x0000,\s*0x0000,\s*0x0000,\s*"
+            r"0x0000,\s*0x0000,\s*0x0000,\s*0x0000,\s*0x0000,\s*0x0000\s*\};",
+        "the former apply words are primary selectors of their own submodes":
+            r"\{\s*0x050D,\s*1\s*\},[\s\S]*\{\s*0x050E,\s*8\s*\},[\s\S]*"
+            r"\{\s*0x0516,\s*4\s*\},[\s\S]*\{\s*0x0515,\s*5\s*\},",
         "shared local split pairs remain explicit":
             r"\{\s*2,\s*3,\s*\"DC current small/A\"\s*\}[\s\S]*"
             r"\{\s*4,\s*5,\s*\"AC current small/A\"\s*\}[\s\S]*"


### PR DESCRIPTION
@DavidClawson — PR (1) from #15, on top of `7175905` (your keepalive gate and `meter_build_tx_frame()`). Three commits: table + header, the transition fixes the bench forced, and EXP-205.

### What changes

1. **One measured word per submode** (`stock_meter_word_low_for_submode[]` in `fpga_meter_plan.c`). `stock_mode` stays as the formatter-family index for `meter_data.c` and the mux projection; it no longer picks the wire word. `fpga_meter_stock_cmd_low_for_mode()` and the apply-word function are gone — the four "apply pairs" are stock's AC/DC toggle, and the second word of each is now the primary selector of ACV, Diode, AC mA, AC A.

   | submode | word | was | | submode | word | was |
   |---|---|---|---|---|---|---|
   | 0 DCV | `050C` | `0514` (Auto) | | 6 Resistance | `050B` | `050A` |
   | 1 ACV | `050D` | `050C` | | 7 Continuity | `0517` | `0511` |
   | 2 DC mA | `0511` | `0517` | | 8 Diode | `050E` | `0510` |
   | 3 DC A | `0510` | `0517` | | 9 Capacitance | `050A` | `0512` |
   | 4 AC mA | `0516` | `050B` | | 10 Temperature | `0512` | `0512` |
   | 5 AC A | `0515` | `050B` | | | | |

   The `14 0c 17 0b 0a 12 11 10` table at `0x080BB3FC` is real (your literal test still pins it), but it is stock's **menu order**, not a mode index.

2. **Header default ON.** `meter hdr off` stays as the negative control.

3. **OBEY is decided by the caller.** Obeyed: the transition's selector (`fpga_wire_send_word`) and the operator's `fpga_send_cmd` / `usart tx` / `fpga wire words`. Everything that has gone out `00 00` since April keeps `00 00`, bit-identical: wake preamble, `fpga_init` and poll-task activation blocks, siggen entry, every scope/config sequence via `fpga_timed_send_cmd`, and the shell's batch replays (`fpga wire entry/scope`, `stock diag bridge`, `spi3 scopetest`). This is the EXP-26 audit: `0x050A` (your "PC7-low probe tail") is the SoC's **Capacitance** selector and `0x0514` ("variant setup") is **Auto**; both sit a few ms after the selector in the mode-entry sequences and, obeyed, would have undone every transition.

4. Header and table are one commit on purpose: under `00 00` a wrong word is discarded; under `AA 55` it is obeyed. Header without table is worse than either alone.

Also: `fpga.h` labels for `0x12/0x13/0x14` now read Temperature/LIVE/Auto; `docs/stock_vs_openscope.md` meter rows say "selected, decoder pending"; `scripts/validate_dmm_goal.py` pinned the old table by regex, anchors updated — your file, redo as you like.

### Bench — EXP-205, unit #2 (`docs/experiments/2026-09-13-205-word-table-and-header-on-unit2.md`)

1. `mode meter N` for N = 0..10: `echo_valid` +1 each, `echo_bad` 0 (24 echoes / 0 bad in the session), frame signature of function N. `meter hdr off`: five sends, no echo, SoC stays in its power-on state.
2. 30 s of keepalive (129 frames): no echo growth, ~6.5 data frames/s, **no relay actuation** (operator, relay pose read back).
3. Loads, hand-decoded: cell 3.862 V; 2.2 kΩ → `2168`; 10 kΩ → `9.924` k; 300 kΩ → `2978` under `f7=0x24` (297.8 k); short → ` 0.17` Ω in Ω and Cont; 10 nF → `9.623` nF; 10 µF → `9.697` µF. Your decoder gets DCV and the two kΩ readings; the rest come back `---`/`ERR`/×100 — PR (2), with these as fixtures.
4. SPI3 15.3 → 14.2 reads/s across scope→meter→scope, 0 timeouts.

### Two defects the bench found, fixed in the second commit

1. **The transition's selector was never accepted.** `AA 55 05 0B` left the wire, no echo came, and **no data frame arrived during the transition** (`data=558..558`); the next frame was the SoC's power-on "Auto" text. `fpga_meter_reset_transport()` drops PC11 and the SoC **restarts**; it is deaf for **1380 ms** (24/24 transitions, a constant on this unit), and the selector 20 ms later is lost. By hand a second later the same word echoed at once. Fix: `fpga_meter_wait_for_soc()` (first frame after PC11, ≤3 s, unobeyed keepalive meanwhile, +200 ms) and `fpga_send_selector_confirmed()` (re-send until echoed, ≤5 × 300 ms). `meter hdr` prints `transition: wake_ms= tries= ok= | unconfirmed= wake_timeouts=`.
2. **One scope→meter entry in three came up with `CTRL1=0x20A0` — UEN set, TE=0 RE=0**: TX climbing into a disabled transmitter, RX frozen. Scope entry parks USART2 with `ctrl1=0`; the reset reads that, quiets 20 ms, restores `ctrl1|UEN|RDBFIEN`; when the display task's `fpga_set_meter_mux(true)` lands inside those 20 ms, the restore overwrites it. The reset now sets TE/RE and the IRQ itself. After: 8/8 first-try, `0x202C` every time.

Something the clicks said: DC mA → DC A produced two clicks with our relay pose unchanged (read back, byte-identical); Cap → Temp none. The SoC has relays of its own and moves them only for an obeyed word that needs it — consistent with the #15 logger (stock's MCU moves no frontend pin across 40 function changes).

### Weaknesses

1. Currents and ACV: word accepted and frame signature seen, no value checked (no source). Temperature: internal sensor only (`  28`).
2. Loads are ±5 % parts and an unlabelled cell; nothing here is calibrated.
3. The 1380 ms wake is one unit's constant; the 3 s timeout has 2.2× margin here only.
4. The SoC's reaction to an obeyed non-`0x05` frame is unmeasured — hence every such sender stays unobeyed rather than "probably fine". On `guest-coldtrace-meter` nothing is transmitted in scope mode, so the scope-side control was vacuous.
5. Legacy sequences are kept as unobeyed traffic rather than deleted: conservative by choice; deletion is a one-liner if you agree that `0x0508/0x0509` and the `00 2C` prefix are display bytes (our reading of the stock binary, hypothesis-grade).

### Three questions, not changes

1. Stock never moves PC11 between functions (#15 logger), so the restart — and 1.4 s per function change — is ours. Your `verify_meter_transition_usart_gate` pins the drop; I left it. Want it gone?
2. EXP-26's "transmit stopped → 0 frames/s" arm was `mode scope`, which also drops PC11. "Answers traffic" may be partly "answers when powered" — worth one re-run with PC11 held high.
3. Your EXP-27 short: `04 E0 1B 4A` has the DP bit in the pre-lookup nibble of digit 2 (`1B` → nibble `0x1A`), so the text is ` 0.14` = **0.14 Ω**, not 0.014 — `0x10` on the leading digit is the blank glyph after lookup. Our leads read ` 0.17` with the same encoding. Prediction: `meter dump` on that frame shows `dbg_nibbles[2] & 0x10`.

### Tests and builds

`make -C firmware test-meter` and every other `test-*` target green; `run_tests.py` 13/13 suites, 95 tests, ratchet clean; `test_dmm_goal_validation.py` 11 OK. All five flavours link: `guest` 614 044 text / .bss +8 vs `7175905` (four counters), `guest-coldtrace` 607 848, `guest-coldtrace-meter` 608 584, `emu` 269 560, `app` 614 148.

Thank you for the replication, for catching the second frame builder, and for the poll gate — without it this would have been a relay-clicking bug report.