### PR TITLE
meter_data: the frame is seven-segment text — read its point, its blanks and its bands

### DIFF
--- a/docs/experiments/2026-09-13-206-decoder-reads-the-text-frames-on-unit2.md
+++ b/docs/experiments/2026-09-13-206-decoder-reads-the-text-frames-on-unit2.md
@@ -1,0 +1,89 @@
+# EXP-206 — The decoder reads the SoC's text frames on unit #2
+
+- **Date:** 2026-09-13
+- **Unit:** bench unit #2 (Stlkv)
+- **Build:** `make guest-coldtrace-meter` from the `meter-word-table` branch (#33) with the
+  decoder commit of this PR cherry-picked on top — the word table is what puts the SoC into
+  the function whose frame is being decoded. Installed in slot B over the port's CDC loader.
+- **Status:** **CONFIRMED**
+
+## 1. Problem
+
+PR (2) teaches `meter_data.c` three things measured in EXP-27/EXP-205: the decimal point is
+in the frame, a leading blank is a space, and the resistance/capacitance bands are in
+`frame[7]`/`frame[6]`. The host tests pin the fixtures; does the firmware decoder produce the
+right number on the device, from the live frame, for the loads that EXP-205 hand-decoded?
+
+## 2. Hypothesis
+
+Every load EXP-205 hand-decoded now comes out of `meter dump` as `display=<that value>
+unit=<that unit>` with `reject=0`, three reads apart, stable to the last digit or one.
+
+- **If true:** the table in §5 matches EXP-205 §5d.
+- **If false:** a value differs by a power of ten or a unit, or `reject` is non-zero.
+
+## 3. Procedure
+
+```
+mode meter N 0           # UI transition, echo-confirmed selector (#33)
+meter dump               # x3, 1.2 s apart: display=, unit=, reject=, frame=
+```
+
+Loads changed by the operator between rows; nothing else touched.
+
+**Preconditions verified by readback:** header `AA 55 (default)`; each transition
+`tries=1 ok=1`; frame signatures per function as in EXP-205 §5c.
+
+## 4. Control
+
+Open probes, recorded first, no hands:
+
+| submode | display | reject | frame[2..11] |
+|---|---|---|---|
+| 6 Ω | `OL` | 0 | `04 F0 6B 01 00 24 00 00 01 35` |
+| 7 Cont | `OL` | 0 | `00 E0 7B 01 00 28 00 00 01 35` |
+| 9 Cap | `0.002 nF` | 0 | `E4 FB EB AB 2D 10 00 00 01 37` |
+| 10 Temp | `30 C` | 0 | `00 00 80 EF 0B 00 20 00 01 34` |
+| 8 Diode | `---` | 1 | `00 F0 6B 01 80 00 02 00 01 39` |
+| 0 DCV | `0.0005 V` | 0 | `F6 EB EB CB 07 00 82 00 01 3A` |
+
+Before this PR the same frames gave `ERR` (Ω, Cont), `---` (Temp) and a ×100 capacitance.
+The diode row is the expected negative: its frame carries the voltage marker `frame[8]=0x02`
+and the family model rejects it — left unchanged in this PR, see the PR text.
+
+## 5. Results
+
+| load | submode | decoder, 3 reads | reject | frame[2..11] | EXP-205 hand decode |
+|---|---|---|---|---|---|
+| 10 kΩ | 6 Ω | 9.929 / 9.929 / 9.929 kOhm | 0 | `C4 DF AF CD 4F 20 00 00 01 33` | `9.924` kΩ |
+| 2.2 kΩ | 6 Ω | 2.168 / 2.169 / 2.169 kOhm | 0 | `A4 0D EA C7 4F 20 80 00 01 35` | `2168` Ω |
+| 2.2 kΩ | 7 Cont | OL / OL / OL | 0 | `00 E0 7B 01 00 28 00 00 01 33` | ` 0L ` |
+| 300 kΩ | 6 Ω | 297.8 / 297.8 / 297.8 kOhm | 0 | `A4 CD 8F EA 0F 24 80 00 01 35` | `2978` × 100 Ω |
+| short | 6 Ω | 0.17 / 0.16 / 0.16 Ohm | 0 | `04 E0 1B EA 07 20 00 00 01 35` | ` 0.17` |
+| short | 7 Cont | 0.16 / 0.17 / 0.17 Ohm | 0 | `00 E0 1B 8A 0A 28 00 00 01 35` | ` 0.17` |
+| 10 nF | 9 Cap | 9.642 / 9.635 / 9.634 nF | 0 | `C4 FF 87 4F 2E 10 00 00 01 3C` | `9.623` nF |
+| 10 µF | 9 Cap | 9.716 / 9.704 / 9.704 uF | 0 | `C4 9F EA 4B 1E 10 00 00 01 3C` | `9.697` µF |
+
+Every row matches the hand decode in value, unit and point; the last-digit drift between
+reads (and against EXP-205, taken an hour earlier) is the SoC's own.
+
+## 6. Blind spots
+
+1. Same ±5 % parts and unlabelled capacitors as EXP-205; no reference instrument. This shows
+   the decoder reproduces the SoC's text, not that the SoC is accurate.
+2. Currents, ACV, diode: not decoded here (no source; diode by design of the family model).
+3. One unit. The unit #1 fixtures in the tests are reconstructions of EXP-27's published
+   bytes, not frames captured through this code.
+4. The bench build is #33 + this PR; on `main` alone the UI would still select the wrong
+   function, so this result is conditional on #33.
+
+## 7. Conclusion
+
+- **Established:** with the word table of #33 selecting the function, the decoder of this
+  PR reads resistance across three bands (0.17 Ω, 2.169 kΩ, 9.929 kΩ, 297.8 kΩ),
+  continuity (0.17 Ω / OL), capacitance in both units (9.64 nF, 9.70 µF) and temperature
+  (30 °C) from live frames, `reject=0`, matching the EXP-205 hand decodes.
+- **Excluded:** the ×100 capacitance and the low-band/upper-band resistance rejects.
+- **NOT excluded:** any accuracy claim; diode (family model); currents and ACV.
+- **Follow-up:** the diode family question and continuity beep policy (PR text); a reference
+  DMM for the S1→S2 promotion the spec asks for.

--- a/firmware/src/drivers/meter_data.c
+++ b/firmware/src/drivers/meter_data.c
@@ -1108,12 +1108,6 @@ static bool frame_has_ac_evidence(uint8_t submode,
            frame_extra_is_empirical_line_frequency_hint(extra);
 }
 
-static bool resistance_low_ohm_calibration_unresolved(uint8_t submode,
-                                                      uint8_t flags)
-{
-    return (submode == 6 || submode == 7) && ((flags & 0xF0U) == 0x00U);
-}
-
 /* ═══════════════════════════════════════════════════════════════════
  * Format value into display string
  * ═══════════════════════════════════════════════════════════════════ */
@@ -1138,12 +1132,15 @@ static void format_reading(meter_reading_t *r, uint8_t submode)
     s[pos] = '\0';
 
     /* Strip leading zeros (but keep at least one digit before decimal) */
-    /* e.g., "0.623" stays, but "0047" becomes "47" */
-    if (dec == 0) {
-        /* No decimal point — strip leading zeros */
+    /* e.g., "0.623" stays, but "0047" becomes "47" and "00.17" becomes "0.17" */
+    {
         int start = r->negative ? 1 : 0;
+        int point = start;
+        while (point < pos && s[point] != '.') {
+            point++;
+        }
         int first_nonzero = start;
-        while (first_nonzero < pos - 1 && s[first_nonzero] == '0') {
+        while (first_nonzero < point - 1 && s[first_nonzero] == '0') {
             first_nonzero++;
         }
         if (first_nonzero > start) {
@@ -1328,6 +1325,44 @@ void meter_data_process_frame(const volatile uint8_t *frame, uint8_t submode)
             (uint8_t)FPGA_METER_FRAME_FAMILY_CONTINUITY;
     }
 
+    /*
+     * THE FRAME IS SEVEN-SEGMENT TEXT (issue #15, EXP-27 on unit #1, EXP-205
+     * on unit #2). Two things the segment lookup throws away are meaning:
+     *
+     *  - bit 4 of a digit's nibble is its DECIMAL POINT, lit on the digit the
+     *    point precedes. The SoC draws "9.924", " 0.17", "9.623" with it, and
+     *    "2168", "2978" without. Exactly one lit DP is a decimal position;
+     *    none means the text is an integer or the submode's own rule applies.
+     *    DCV is excluded here: its point rides the stock range classes and the
+     *    +10000 extension below, which were measured separately.
+     *  - a leading blank glyph is a leading SPACE: " 0.17", "  28". Those
+     *    digits are zeros for the value and nothing for the display; they are
+     *    not the blank/partial-blank special frames, which are blank all the
+     *    way through.
+     */
+    uint8_t dp_bits = (uint8_t)(((nib0 & 0x10U) ? 1U : 0U) | ((nib1 & 0x10U) ? 2U : 0U) |
+                                ((nib2 & 0x10U) ? 4U : 0U) | ((nib3 & 0x10U) ? 8U : 0U));
+    uint8_t frame_dp = (dp_bits == 2U) ? 1U : (dp_bits == 4U) ? 2U : (dp_bits == 8U) ? 3U : 0U;
+    uint8_t text_codes[4] = { digit0, digit1, digit2, digit3 };
+    uint8_t leading_blanks = 0;
+    bool text_numeric = false;
+    while (leading_blanks < 3U && text_codes[leading_blanks] == 0x10U) {
+        leading_blanks++;
+    }
+    if (leading_blanks > 0) {
+        text_numeric = true;
+        for (uint8_t k = leading_blanks; k < 4U; k++) {
+            if (text_codes[k] > 9U) text_numeric = false;
+        }
+    }
+    if (text_numeric) {
+        for (uint8_t k = 0; k < leading_blanks; k++) text_codes[k] = 0;
+        digit0 = text_codes[0];
+        digit1 = text_codes[1];
+        digit2 = text_codes[2];
+        digit3 = text_codes[3];
+    }
+
     /* Parse status flags from byte [7]. The stock parser treats this as the
      * status byte for data frames and as an integrity marker for echo frames. */
     uint8_t status = frame[7];
@@ -1413,8 +1448,11 @@ void meter_data_process_frame(const volatile uint8_t *frame, uint8_t submode)
         return;
     }
 
-    /* Overload: "OL" */
-    if (digit0 == 0x0A && digit1 == 0x0B) {
+    /* Overload: "OL", and the SoC's other spelling " 0L " (blank, 0, L,
+     * blank) -- what resistance shows on open probes, continuity above its
+     * threshold and diode above its range (units #1 and #2). */
+    if ((digit0 == 0x0A && digit1 == 0x0B) ||
+        (digit0 == 0x10 && digit1 == 0x00 && digit2 == 0x0E && digit3 == 0x10)) {
         meter_clear_payload(r);
         r->result_class = METER_RESULT_OVERLOAD;
         strcpy(r->display_str, "OL");
@@ -1473,7 +1511,7 @@ void meter_data_process_frame(const volatile uint8_t *frame, uint8_t submode)
         return;
     }
 
-    if (!raw_digits_are_all_bcd(r->dbg_raw_digits)) {
+    if (!raw_digits_are_all_bcd(text_codes)) {
         /*
          * The segment lookup returns real digit values only for 0..9. Other
          * stock-visible codes represent OL glyphs, blanks, continuity icons,
@@ -1492,12 +1530,6 @@ void meter_data_process_frame(const volatile uint8_t *frame, uint8_t submode)
     }
 
     /* --- Normal BCD value --- */
-
-    if (resistance_low_ohm_calibration_unresolved(submode, flags)) {
-        r->reject_reason = METER_REJECT_UNRESOLVED_CALIBRATION;
-        METER_REJECT_FRAME();
-        return;
-    }
 
     uint8_t d0 = digit0;
     uint8_t d1 = digit1;
@@ -1529,6 +1561,13 @@ void meter_data_process_frame(const volatile uint8_t *frame, uint8_t submode)
 
     meter_stock_fsm_apply(submode, frame, raw_digit_codes);
     r->decimal_pos = decimal_pos_from_stock(submode, &meter_stock_fsm);
+    if (submode != 0) {
+        if (frame_dp) {
+            r->decimal_pos = frame_dp;          /* the SoC's own point */
+        } else if (text_numeric || submode == 6 || submode == 7) {
+            r->decimal_pos = 0;                 /* "  28", "2168": no point, an integer */
+        }
+    }
     r->unit_variant = meter_stock_fsm.variant;
     r->unit_suffix = unit_suffix_from_stock(submode, meter_stock_fsm.unit_index);
     (void)apply_stock_dcv_voltage_range_hint(r, submode, frame);
@@ -1544,59 +1583,79 @@ void meter_data_process_frame(const volatile uint8_t *frame, uint8_t submode)
     r->continuity_beep = false;
     format_reading(r, submode);
     (void)apply_stock_dcv_decimal_exponent(r, submode, frame);
+    if (submode != 0 && r->decimal_pos == 0) {
+        /* format_reading()'s divisor treats position 0 as four decimals and
+         * leaves DCV to the class path above; outside DCV, no point means the
+         * text is the integer it shows. */
+        r->value = (float)r->bcd_value;
+        if (r->negative) r->value = -r->value;
+    }
 
-    /* ── Resistance kOhm band unit normalization ──
+    /*
+     * Resistance and continuity: the SoC's text and its range bits, no
+     * per-unit coefficient (the 0.0304 low-ohm factor is withdrawn -- shorted
+     * probes read as " 0.17" on unit #2 and " 0.14" on unit #1, which is lead
+     * resistance, not 0.5 Ohm). Measured on both units, EXP-27 / EXP-205:
      *
-     * For resistance/continuity submodes, the FPGA meter IC rotates
-     * through multiple frame variants per measurement, each claiming
-     * a different dp/unit. The "correct" interpretation depends on
-     * which specific frame[6] we happen to catch — without override,
-     * the display flickers between e.g. "9.821 kOhm" and "98.24 kOhm"
-     * for the SAME 10 kΩ resistor.
+     *   frame[7] & 0x04           upper band: digits are hundreds of ohms and
+     *                             carry no point ("2978" -> 297.8 kOhm)
+     *   a point in the frame      the text as shown; frame[6] upper nibble 4
+     *                             is the kOhm regime ("9.924" -> 9.924 kOhm),
+     *                             otherwise ohms (" 0.17" -> 0.17 Ohm)
+     *   no point                  integer ohms; in the kOhm regime shown with
+     *                             three decimals ("2168" -> 2.168 kOhm)
      *
-     * Only the kOhm band is normalized here:
-     *
-     *   kOhm band (frame[6] upper nibble 4): value = bcd_value * 0.001 kOhm
-     *
-     * The low-Ohm band is rejected above until its factory calibration source is
-     * recovered. The 0.001 kOhm factor is a geometric identity (raw counts
-     * already expressed in Ohm, shifted to kOhm) and should be stable across
-     * units.
-     *
-     * Higher bands (MΩ, autorange to 200 kΩ / 2 MΩ) are not yet
-     * characterized — those will need additional upper-nibble cases.
-     *
-     * We leave bcd_value, decimal_pos, and digits[] untouched so the
-     * debug overlay at meter_ui.c:948 still shows the FPGA's raw
-     * pre-cal report. UI code reads `value` and `display_str` for
-     * the final numbers.
+     * The continuity submode reads the same text (" 0.17" on shorted probes,
+     * " 0L " above the SoC's threshold); whether a number there should also
+     * beep is display policy and is left as it was.
      */
     if (submode == 6 || submode == 7) {
-        float       scale = 0.0f;
-        const char *unit  = NULL;
+        char *s = r->display_str;
+        bool kohm_regime = (flags & 0xF0U) == 0x40U;
 
-        switch (flags & 0xF0) {
-        case 0x40:  scale = METER_KOHM_UNIT_FACTOR; unit = "kOhm"; break;
-        default:    break;  /* Unknown band — leave format_reading's output */
+        if (status & 0x04U) {
+            float kohm = (float)r->bcd_value * 0.1f;
+            r->value = kohm;
+            r->unit_suffix = "kOhm";
+            r->decimal_pos = 0;
+            format_4digit_unsigned(kohm, s);
+        } else if (frame_dp) {
+            r->unit_suffix = kohm_regime ? "kOhm" : "Ohm";
+        } else if (kohm_regime) {
+            float kohm = (float)r->bcd_value * METER_KOHM_UNIT_FACTOR;
+            r->value = kohm;
+            r->unit_suffix = "kOhm";
+            format_4digit_unsigned(kohm, s);
+        } else {
+            r->unit_suffix = "Ohm";
         }
-
-        if (scale != 0.0f) {
-            float v = (float)r->bcd_value * scale;
-            if (r->negative) v = -v;
-            r->value       = v;
-            r->unit_suffix = unit;
-
-            char *s = r->display_str;
-            int   pos = 0;
-            float av  = v;
-            if (av < 0.0f) { s[pos++] = '-'; av = -av; }
-            format_4digit_unsigned(av, s + pos);
-
-            /* Recompute bar graph fraction from the corrected value. */
-            float abs_v = v < 0.0f ? -v : v;
+        {
+            float abs_v = r->value < 0.0f ? -r->value : r->value;
             float full_scale = (submode < 11) ? bar_full_scale[submode] : 1000.0f;
             r->bar_fraction = abs_v / full_scale;
             if (r->bar_fraction > 1.0f) r->bar_fraction = 1.0f;
+        }
+    }
+
+    /*
+     * Capacitance: the frame describes itself (unit #2, EXP-205 and five
+     * capacitors on 2026-09-07). frame[7] == 0x10 marks the function; the
+     * unit is frame[6]'s upper nibble, 0x2_ nF and 0x1_ uF; the point is in
+     * the digits ("9.623" nF, "9.697" uF, "100.6" nF, "90.36" uF). The mF
+     * range was never on the bench, so any other nibble is refused rather
+     * than guessed. Synthetic frames without the 0x10 marker keep the stock
+     * formatter's default, which is what the older tests describe.
+     */
+    if (submode == 9 && status == 0x10U) {
+        uint8_t cap_unit = (uint8_t)(flags & 0xF0U);
+        if (cap_unit == 0x20U) {
+            r->unit_suffix = "nF";
+        } else if (cap_unit == 0x10U) {
+            r->unit_suffix = "uF";
+        } else {
+            r->reject_reason = METER_REJECT_UNSUPPORTED_EXTENSION;
+            METER_REJECT_FRAME();
+            return;
         }
     }
 

--- a/firmware/tests/test_meter_data.c
+++ b/firmware/tests/test_meter_data.c
@@ -824,17 +824,18 @@ static int test_passive_formatter_debug_fields_cover_diode_and_extended_splits(v
     return 1;
 }
 
-static int test_resistance_low_ohm_fails_closed_without_factory_cal(void)
+static int test_resistance_low_band_reads_the_soc_text_as_ohms(void)
 {
     uint8_t frame[12];
 
+    /* frame[6] upper nibble 0, no point: the digits are ohms as the SoC shows
+     * them. This used to fail closed for want of a per-unit low-ohm factor;
+     * the factor was the auto-mode artefact (issue #15), the text is the value. */
     meter_data_init();
     build_segment_frame(frame, 4, 8, 2, 4, 0x00, 0x00, 0x00, 0x00, 0);
     process_frame(frame, 6);
-    ASSERT(!meter_reading.valid);
-    ASSERT(meter_reading.reject_reason == METER_REJECT_UNRESOLVED_CALIBRATION);
-    ASSERT_STR_EQ(meter_reading.display_str, "---");
-    ASSERT(meter_reading.result_class == METER_RESULT_NONE);
+    ASSERT(expect_normal_reading("4824", "Ohm", 4824.0f, 0.5f));
+    ASSERT(meter_reading.reject_reason == METER_REJECT_NONE);
 
     build_segment_frame(frame, 3, 3, 0, 0, 0x40, 0x00, 0x00, 0x00, 0);
     process_frame(frame, 6);
@@ -2688,6 +2689,161 @@ static int test_snapshot_rejects_concurrent_two_writer_window(void)
     return 1;
 }
 
+/* ═══════════════════════════════════════════════════════════════════
+ * Live frames from two units (issue #15). The frame is seven-segment text:
+ * bit 4 of a digit's nibble is its decimal point, a leading blank glyph is a
+ * space. Unit #2 frames: EXP-205 (2026-09-13) and the 2026-09-07 bench; unit
+ * #1 frames: EXP-27, bytes[2..5] and frame[6] as published, frame[7] = 0x20
+ * assumed (the same regime as unit #2's), so those two are labelled.
+ * ═══════════════════════════════════════════════════════════════════ */
+
+static void raw_frame(uint8_t frame[12], const char *hex24)
+{
+    for (int i = 0; i < 12; i++) {
+        unsigned v = 0;
+        sscanf(hex24 + 2 * i, "%2x", &v);
+        frame[i] = (uint8_t)v;
+    }
+}
+
+static int test_live_frames_carry_their_own_decimal_point(void)
+{
+    uint8_t frame[12];
+
+    meter_data_init();
+    /* 10 kOhm, unit #2: "9.924", point on digit 1, frame[6] 0x4E, frame[7] 0x20 */
+    raw_frame(frame, "5AA5C4DFAF4D4E200000012F");
+    process_frame(frame, 6);
+    ASSERT(expect_normal_reading("9.924", "kOhm", 9.924f, 0.0005f));
+    ASSERT(meter_reading.decimal_pos == 1);
+
+    /* 2.2 kOhm, unit #2: "2168", no point, frame[6] 0x4F -> 2.168 kOhm */
+    raw_frame(frame, "5AA5A40DEAE74F208000012E");
+    process_frame(frame, 6);
+    ASSERT(expect_normal_reading("2.168", "kOhm", 2.168f, 0.0005f));
+
+    /* ACV mains, upstream's own fixture: the point sits on digit 3 -> 226.6 V */
+    raw_frame(frame, "5AA5A5ADEDF7070002000032");
+    process_frame(frame, 1);
+    ASSERT(expect_normal_reading("226.6", "V", 226.6f, 0.05f));
+    ASSERT(meter_reading.decimal_pos == 3);
+
+    /* DCV is untouched by the point: the stock classes still rule there */
+    raw_frame(frame, "5AA54ECE8F8A0A0082000173");
+    process_frame(frame, 0);
+    ASSERT(meter_reading.valid);
+    ASSERT_STR_EQ(meter_reading.display_str, "1.4977");
+    return 1;
+}
+
+static int test_live_resistance_bands_unit2_and_unit1(void)
+{
+    uint8_t frame[12];
+
+    meter_data_init();
+    /* shorted probes, unit #2, resistance: " 0.17", frame[7] 0x20 */
+    raw_frame(frame, "5AA504E01B8A0A2000000131");
+    process_frame(frame, 6);
+    ASSERT(expect_normal_reading("0.17", "Ohm", 0.17f, 0.0005f));
+
+    /* the same leads in continuity, frame[7] 0x28: same text, same value */
+    raw_frame(frame, "5AA500E01B8A0A2800000132");
+    process_frame(frame, 7);
+    ASSERT(meter_reading.valid);
+    ASSERT_STR_EQ(meter_reading.display_str, "0.17");
+    ASSERT_STR_EQ(meter_reading.unit_suffix, "Ohm");
+    ASSERT(close_to(meter_reading.value, 0.17f, 0.0005f));
+
+    /* 300 kOhm, unit #2: "2978", frame[7] 0x24 -> hundreds of ohms -> 297.8 kOhm */
+    raw_frame(frame, "5AA5A4CD8FEA0F2480000132");
+    process_frame(frame, 6);
+    ASSERT(expect_normal_reading("297.8", "kOhm", 297.8f, 0.05f));
+
+    /* open probes in resistance, unit #2: " 0L " in the upper band -> OL */
+    raw_frame(frame, "5AA504F06B0100240000010B");
+    process_frame(frame, 6);
+    ASSERT(meter_reading.valid);
+    ASSERT(meter_reading.result_class == METER_RESULT_OVERLOAD);
+    ASSERT_STR_EQ(meter_reading.display_str, "OL");
+
+    /* unit #1, EXP-27, 10 kOhm: bytes[2..5] C4 9F 8A CA, frame[6] 0x47 -> "9775" */
+    raw_frame(frame, "5AA5C49F8ACA472080000000");
+    process_frame(frame, 6);
+    ASSERT(expect_normal_reading("9.775", "kOhm", 9.775f, 0.0005f));
+
+    /* unit #1, EXP-27, shorted probes: 04 E0 1B 4A, frame[6] 0x0F. The point
+     * is in the pre-lookup nibble of digit 2 (0x1A), so this is " 0.14" =
+     * 0.14 Ohm, not the 0.014 the digit codes alone suggested. frame[6] is
+     * the 0x0E of his rotation that completes digit 3 as a "4". */
+    raw_frame(frame, "5AA504E01B4A0E2000000000");
+    process_frame(frame, 6);
+    ASSERT(expect_normal_reading("0.14", "Ohm", 0.14f, 0.0005f));
+    return 1;
+}
+
+static int test_live_capacitance_frames_self_describe(void)
+{
+    uint8_t frame[12];
+
+    meter_data_init();
+    raw_frame(frame, "5AA5C4FFA78D2F100000013A");        /* 10 nF, EXP-205 */
+    process_frame(frame, 9);
+    ASSERT(expect_normal_reading("9.623", "nF", 9.623f, 0.0005f));
+
+    raw_frame(frame, "5AA5C4FFC78F1A100000013A");        /* 10 uF, EXP-205 */
+    process_frame(frame, 9);
+    ASSERT(expect_normal_reading("9.697", "uF", 9.697f, 0.0005f));
+
+    raw_frame(frame, "5AA504EAEBFB2710000000DB");        /* 100 nF, 2026-09-07 */
+    process_frame(frame, 9);
+    ASSERT(expect_normal_reading("100.6", "nF", 100.6f, 0.05f));
+
+    raw_frame(frame, "5AA5C4EF9BEF1710000000DB");        /* 100 uF, 2026-09-07 */
+    process_frame(frame, 9);
+    ASSERT(expect_normal_reading("90.36", "uF", 90.36f, 0.005f));
+
+    raw_frame(frame, "5AA5E4FBEBEB2F10000000DB");        /* open probes: 0.008 nF */
+    process_frame(frame, 9);
+    ASSERT(expect_normal_reading("0.008", "nF", 0.008f, 0.0005f));
+
+    raw_frame(frame, "5AA504100000201000000011");        /* ranging: blank digits */
+    process_frame(frame, 9);
+    ASSERT(meter_reading.valid);
+    ASSERT(meter_reading.result_class == METER_RESULT_BLANK);
+
+    /* an unmeasured unit nibble (mF was never on the bench) is refused, not guessed */
+    raw_frame(frame, "5AA5C4FFA78D3F100000013A");
+    process_frame(frame, 9);
+    ASSERT(!meter_reading.valid);
+    ASSERT(meter_reading.reject_reason == METER_REJECT_UNSUPPORTED_EXTENSION);
+    return 1;
+}
+
+static int test_live_ol_second_spelling_and_leading_blanks(void)
+{
+    uint8_t frame[12];
+
+    meter_data_init();
+    /* 2.2 kOhm in continuity, unit #2: " 0L " -> OL, not ERR */
+    raw_frame(frame, "5AA500E07B0100280000012F");
+    process_frame(frame, 7);
+    ASSERT(meter_reading.valid);
+    ASSERT(meter_reading.result_class == METER_RESULT_OVERLOAD);
+    ASSERT_STR_EQ(meter_reading.display_str, "OL");
+
+    /* temperature, internal sensor, unit #2: "  28" -> 28 C */
+    raw_frame(frame, "5AA50000A0ED0F002000011F");
+    process_frame(frame, 10);
+    ASSERT(expect_normal_reading("28", "C", 28.0f, 0.5f));
+    ASSERT(meter_reading.decimal_pos == 0);
+
+    /* a fully blank frame is still the blank special, not a zero reading */
+    build_segment_frame(frame, 0x10, 0x10, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00, 0);
+    process_frame(frame, 6);
+    ASSERT(meter_reading.result_class == METER_RESULT_BLANK);
+    return 1;
+}
+
 int main(void)
 {
     printf("Meter data frame tests\n");
@@ -2716,7 +2872,11 @@ int main(void)
     TEST(ac_modes_require_frequency_hint_boundaries);
     TEST(stock_formatter_families_have_regression_fixtures);
     TEST(passive_formatter_debug_fields_cover_diode_and_extended_splits);
-    TEST(resistance_low_ohm_fails_closed_without_factory_cal);
+    TEST(resistance_low_band_reads_the_soc_text_as_ohms);
+    TEST(live_frames_carry_their_own_decimal_point);
+    TEST(live_resistance_bands_unit2_and_unit1);
+    TEST(live_capacitance_frames_self_describe);
+    TEST(live_ol_second_spelling_and_leading_blanks);
     TEST(invalidate_clears_stale_reading_before_mode_transition);
     TEST(invalidate_clears_stale_reading_for_every_submode);
     TEST(parser_stock_mode_tracks_transition_plan_for_every_submode);


### PR DESCRIPTION
@DavidClawson — PR (2) from #15. Branches from `7175905`, independent of #33 and #34 in code; the fixtures come from unit #2 (EXP-205, 2026-09-07) and from your EXP-27 frames.

### What changes in `meter_data.c`

1. **The decimal point is in the frame.** Bit 4 of a digit's nibble (before `bcd_lookup`, which masks it) is the seven-segment DP, lit on the digit it precedes. Exactly one lit DP sets `decimal_pos` for every submode except DCV, whose point rides your stock range classes and the +10000 extension and is untouched. Your existing mains fixture already carries it (`… ED F7 07` → point on digit 3 → 226.6 V in ACV).
2. **A leading blank glyph is a leading space.** `" 0.17"`, `"  28"`: those digits are zeros for the value and nothing for the display. A frame blank all the way through is still the blank special.
3. **The other spelling of OL.** `" 0L "` — blank, 0, L, blank — is what resistance shows on open probes, continuity above its threshold and diode above its range. It was `ERR`.
4. **Resistance / continuity bands, without a coefficient.** `frame[7] & 0x04` → digits are hundreds of ohms (`"2978"` → 297.8 kΩ); a point in the frame → the text as shown, kΩ when `frame[6]`'s upper nibble is 4 (`"9.924"`), else Ω (`" 0.17"`); no point → integer ohms, shown as `X.XXX kOhm` in the kΩ regime (`"2168"` → 2.168 kOhm, your existing rule) else `Ohm`. The `METER_REJECT_UNRESOLVED_CALIBRATION` path for `frame[6]` upper nibble 0 is gone: the 0.0304 factor you withdrew was the auto-mode artefact, and the low band reads as text on both units.
5. **Capacitance describes itself.** `frame[7] == 0x10` marks the function; the unit is `frame[6]`'s upper nibble, `0x2_` nF and `0x1_` µF; the point is in the digits. Any other nibble is refused (`UNSUPPORTED_EXTENSION`) — mF was never on a bench. Synthetic frames without the `0x10` marker keep the stock formatter's default, so your existing capacitance tests still describe them.
6. Outside DCV, `decimal_pos == 0` now means "the integer shown"; `format_reading()` also strips leading zeros ahead of a point (`"00.17"` → `"0.17"`).

Not changed, on purpose (two things the bench says, both against the current family model — your call):

- **Diode frames carry the voltage marker.** Both diode frames on unit #2 (`" 0L "` above range, `1.346 V` on a cell) have `frame[8] = 0x02`, so submode 8 rejects them as a foreign family. Making the diode family accept the marker touches five of your family-matrix tests; I left it out and the diode still reads `---`.
- **Continuity beeps only on the marker glyphs.** The SoC in continuity sends `" 0.17"` (a number) or `" 0L "`, never the `0x12 0x0A 5` pattern, on unit #2. A number in submode 7 now reads as 0.17 Ohm, `NORMAL`, no beep — as your tests specify.

### Fixtures (all raw 12-byte frames, `test_meter_data.c`)

Unit #2: 10 kΩ `"9.924"`, 2.2 kΩ `"2168"`, short `" 0.17"` in Ω and Cont, 300 kΩ `"2978"`/`f7=0x24`, open Ω `" 0L "`, 10 nF `"9.623"`, 10 µF `"9.697"`, 100 nF, 100 µF, open Cap, the ranging blank frame, an unmeasured unit nibble (refused), Cont on 2.2 kΩ `" 0L "`, temperature `"  28"`, DCV unchanged at `1.4977`.

Unit #1, your EXP-27, reconstructed from the bytes you published (`frame[7] = 0x20` assumed, labelled): 10 kΩ `C4 9F 8A CA`/`0x47` → 9.775 kOhm ✅ your value. Shorted probes `04 E0 1B 4A`: the DP bit is in the pre-lookup nibble of digit 2 (`1B 4A` → `0x1A`), so the text is `" 0.14"` = **0.14 Ω**, not 0.014 — `0x10` on the leading digit is the blank glyph after lookup, not a point. 0.14 Ω is also an ordinary lead resistance where 14 mΩ is not. Prediction you can check: `meter dump` on that frame shows `dbg_nibbles[2] & 0x10`.

### Tests and gates

`test-meter-data` 72/72 (68 + 4 new, one rewritten: the low-band reject became a reading); `test-meter` all green; `test_dmm_goal_validation.py` OK and every static gate in `validate_dmm_goal.py` passes unchanged; `run_tests.py` 13/13. All five flavours link: `guest` 613 880 text / .bss 227 284 (unchanged vs `7175905`), `guest-coldtrace` 607 812, `guest-coldtrace-meter` 608 436, `emu` 269 500, `app` 613 984.

### Bench — EXP-206, unit #2 (`docs/experiments/2026-09-13-206-decoder-reads-the-text-frames-on-unit2.md`)

`guest-coldtrace-meter` built from #33 with this commit on top (the table selects the function, the decoder reads it), loads swapped by hand, three `meter dump` reads each, `reject=0` on every row:

| load | decoder | before |
|---|---|---|
| 10 kΩ | 9.929 kOhm | 9.924 kOhm |
| 2.2 kΩ | 2.169 kOhm | 2.168 kOhm |
| 2.2 kΩ, Cont | OL | `ERR` |
| 300 kΩ | 297.8 kOhm | `---`, reject=4 |
| short, Ω and Cont | 0.16–0.17 Ohm | `ERR` |
| 10 nF | 9.63 nF | 962.3 nF |
| 10 µF | 9.70 uF | 969.7 nF |
| open Ω / Cont | OL / OL | `ERR` |
| internal temperature | 30 C | `---` |

Diode still `---` (`reject=1`), as described above.

### Weaknesses

1. Currents and ACV values are untested; the AC-evidence gate is untouched.
2. mF and the MΩ band were never on the bench; the code refuses the former and has no rule for the latter.
3. Unit #1 fixtures are reconstructions of published bytes, not captured frames.
4. Two ±5 % resistors and unlabelled capacitors; nothing here is calibrated.
